### PR TITLE
temp solution for UDLs to log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,8 @@ add_custom_command(TARGET clusters_search_udl POST_BUILD
         ${CMAKE_CURRENT_BINARY_DIR}/
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/client_query.py
         ${CMAKE_CURRENT_BINARY_DIR}/
+    COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/perf_test_setup.py
+        ${CMAKE_CURRENT_BINARY_DIR}/
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/perf_test_client.py
         ${CMAKE_CURRENT_BINARY_DIR}/
     COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/perf_config.py

--- a/perf_test_client.py
+++ b/perf_test_client.py
@@ -85,7 +85,7 @@ def main(argv):
                time.sleep(RETRIEVE_WAIT_INTERVAL)
                wait_time += RETRIEVE_WAIT_INTERVAL
 
-     tl.flush("perf_test_client.dat")
+     tl.flush(f"client_timestamp.dat")
      print("Done!")
 
 if __name__ == "__main__":

--- a/python_udls/aggregate_generate.py
+++ b/python_udls/aggregate_generate.py
@@ -171,9 +171,11 @@ class AggregateGenerateUDL(UserDefinedLogic):
                     print(f"[AggregateGenerate] put the agg_results to key:{next_key},\
                               \n                   value: {sorted_client_query_batch_result}")
                self.tl.log(LOG_TAG_AGG_UDL_PUT_RESULT_END, self.my_id, query_batch_id, 0)
-          
+               # TODO: figure out a better way to flush the logs
+               if query_batch_id == NUM_BATCH_REQUESTS - 1:
+                    self.tl.flush("udls_timestamp.dat")
           self.tl.log(LOG_TAG_AGG_UDL_END, self.my_id, qb_qid, cluster_id)
-
+          
 
                
 


### PR DESCRIPTION
Note: this current method of adding flush in aggregate udl when it finishes last batch of queries, is only a temporary solution. It doesn't work when there are multiple servers that are running UDLs. Need to find better solution and fix it.