### PR TITLE
Recall Client v0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pickle
+*.tar
+*.tar.*
+gist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.tar
 *.tar.*
 gist/
+miniset/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,14 @@ target_compile_definitions(latency_client PRIVATE
     ENABLE_VORTEX_EVALUATION_LOGGING=${ENABLE_VORTEX_EVALUATION_LOGGING}
 )
 
+add_executable(recall_client vortex_client/recall_client.cpp)
+target_link_libraries(recall_client cascade pthread)
+target_compile_definitions(recall_client PRIVATE
+    LOG_TAG_QUERIES_SENDING_START=${LOG_TAG_QUERIES_SENDING_START}
+    LOG_TAG_QUERIES_SENDING_END=${LOG_TAG_QUERIES_SENDING_END}
+    LOG_TAG_QUERIES_RESULT_CLIENT_RECEIVED=${LOG_TAG_QUERIES_RESULT_CLIENT_RECEIVED}
+    ENABLE_VORTEX_EVALUATION_LOGGING=${ENABLE_VORTEX_EVALUATION_LOGGING}
+)
 
 
 # Centroids_search UDL tags
@@ -221,6 +229,10 @@ add_custom_command(TARGET aggregate_generate_udl POST_BUILD
         ${CMAKE_CURRENT_BINARY_DIR}/cfg/n2/latency_client
     COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/latency_client
         ${CMAKE_CURRENT_BINARY_DIR}/cfg/n3/latency_client
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/recall_client
+        ${CMAKE_CURRENT_BINARY_DIR}/cfg/n2/recall_client
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/recall_client
+        ${CMAKE_CURRENT_BINARY_DIR}/cfg/n3/recall_client
     COMMAND chmod 755 ${CMAKE_CURRENT_BINARY_DIR}/cfg/run.sh.tmp
     COMMAND chmod 755 ${CMAKE_CURRENT_BINARY_DIR}/cfg/clear_log.sh.tmp
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cfg/run.sh.tmp

--- a/cfg/dfgs.json.tmp
+++ b/cfg/dfgs.json.tmp
@@ -39,7 +39,8 @@
                 { 
                         "top_num_centroids":2,
                         "final_top_k":2,
-                        "include_llm":false
+                        "include_llm":false,
+                        "retrieve_docs":true
                 }],
                 "destinations": [{}]
             }

--- a/setup/perf_data/download_gist.sh
+++ b/setup/perf_data/download_gist.sh
@@ -1,0 +1,2 @@
+wget -O gist.tar.gz ftp://ftp.irisa.fr/local/texmex/corpus/gist.tar.gz
+tar -xvzf gist.tar.gz

--- a/setup/perf_data/format_gist.py
+++ b/setup/perf_data/format_gist.py
@@ -1,0 +1,91 @@
+import numpy as np
+import faiss
+import pickle
+import os 
+
+EMBEDDINGS_LOC = './gist'
+
+def fvecs_read(filename, dtype=np.float32, c_contiguous=True):
+    fv = np.fromfile(filename, dtype=dtype)
+    if fv.size == 0:
+        return np.zeros((0, 0))
+    dim = fv.view(np.int32)[0]
+    assert dim > 0
+    fv = fv.reshape(-1, 1 + dim)
+    if not all(fv.view(np.int32)[:, 0] == dim):
+        raise IOError("Non-uniform vector sizes in " + filename)
+    fv = fv[:, 1:]
+    if c_contiguous:
+        fv = fv.copy()
+    return fv
+
+base = fvecs_read('./gist/gist_base.fvecs')
+print("Base shape", base.shape)
+#print(base[0])
+
+
+groundtruth = fvecs_read('./gist/gist_groundtruth.ivecs', np.int32)
+print("groundtruth shape",groundtruth.shape)
+#print(groundtruth[0])
+
+query = fvecs_read('./gist/gist_query.fvecs')
+print("query shape", query.shape)
+
+
+dimension = base.shape[1]  # Assumes emb_list is a 2D array (num_embeddings, embedding_dim)
+print("dimension", dimension)
+# Create a FAISS index, here we're using an IndexFlatL2 which is a basic index with L2 distance
+index = faiss.IndexFlatL2(dimension)
+
+# Add embeddings to the index
+index.add(base)
+
+# Search for the nearest 5 neighbors
+k = 5  # number of nearest neighbors
+distances, indices = index.search(query[0].reshape(1, -1), k)
+
+# Print the results
+print("Indices of nearest neighbors:", indices)
+print("Distances to nearest neighbors:", distances)
+print("groundtruth", groundtruth[0])
+
+
+doc_emb_map = {0:{}}
+for i in range(len(base)):
+    doc_emb_map[0][i] = i
+
+querytexts = []
+
+for i in range(len(query)):
+    querytexts.append("Query " + str(i))
+
+
+testcentroid = np.zeros((1, 960))
+
+
+os.makedirs(EMBEDDINGS_LOC, exist_ok=True)
+
+with open(f'{EMBEDDINGS_LOC}/centroids.pkl', 'wb') as file:
+    pickle.dump(testcentroid, file)
+
+with open(f'{EMBEDDINGS_LOC}/embeddings_list.pkl', 'wb') as f:
+    pickle.dump(base, f)
+
+with open(f'{EMBEDDINGS_LOC}/cluster_0.pkl', 'wb') as f:
+    pickle.dump(base, f)
+
+with open(f'{EMBEDDINGS_LOC}/doc_emb_map.pkl', 'wb') as f:
+    pickle.dump(doc_emb_map, f)
+
+
+np.savetxt(f'{EMBEDDINGS_LOC}/groundtruth.csv', groundtruth, delimiter=",", fmt='%i')
+np.savetxt(f'{EMBEDDINGS_LOC}/query.csv', querytexts, fmt="%s")
+np.savetxt(f'{EMBEDDINGS_LOC}/query_emb.csv', query, delimiter=",")
+
+
+
+# np.save("gist/embeddings.npy", base, False)
+# np.save("gist/groundtruth.npy", groundtruth, False)
+# np.save("gist/query.npy", query, False)
+
+# np.save("gist/cluster_0.npy", base, False)

--- a/setup/perf_test_setup_gist.py
+++ b/setup/perf_test_setup_gist.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import os
+import pickle
+import sys
+import time
+import json
+from derecho.cascade.external_client import ServiceClientAPI
+
+
+NUM_EMB_PER_OBJ = 200  # < 1MB/4KB = 250
+EMBEDDING_DIM = 960
+NUM_KEY_PER_MAP_OBJ = 50000 # takes around 1MB memory
+FLOAT_POINT_SIZE = 32  # currently only support 32-bit float TODO: add support for 64-bit float
+
+np.random.seed(1234)             # make reproducible
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+OBJECT_POOLS_LIST = "object_pools.list"
+
+DOC_EMB_MAP_FILENAME = "doc_emb_map.pkl"
+#DOC_LIST_FILENAME = "doc_list.pkl"
+CENTROIDS_FILENAME = "centroids.pkl"
+CLUSTER_FILE_PREFIX = "cluster_"
+
+
+SUBGROUP_TYPES = {
+        "VCSS": "VolatileCascadeStoreWithStringKey",
+        "PCSS": "PersistentCascadeStoreWithStringKey",
+        "TCSS": "TriggerCascadeNoStoreWithStringKey"
+        }
+
+
+
+
+def create_object_pool(capi, basepath):
+    # create object pools
+    print("Creating object pools ...")
+    fpath = os.path.join(basepath,OBJECT_POOLS_LIST)
+    with open(fpath,"r") as list_file:
+        for line in list_file:
+            fields = line.strip().split(" ")
+            pool_path = fields[0]
+            subgroup_type = fields[1]
+            subgroup_index = int(fields[2])
+            if len(fields) >= 4:
+                affinity_set_regex = fields[3].strip()
+                res = capi.create_object_pool(pool_path,SUBGROUP_TYPES[subgroup_type],
+                                              subgroup_index,
+                                              affinity_set_regex=affinity_set_regex)
+                if res:
+                    res.get_result()
+                else:
+                    print(f"Failed to create the object pool: {pool_path}")
+                    exit(1)
+            else:
+                print(f"  {pool_path} {subgroup_type} {subgroup_index}")
+                res = capi.create_object_pool(pool_path,
+                                              SUBGROUP_TYPES[subgroup_type],
+                                              subgroup_index)
+                if res:
+                    res.get_result()
+                else:
+                    print(f"Failed to create the object pool: {pool_path}")
+                    exit(1)
+
+
+def get_embeddings(basepath, filename, d=1024):
+    '''
+    Load the embeddings from a pickle file.
+    '''
+    fpath = os.path.join(basepath, filename)
+    with open(fpath, 'rb') as file:
+        data = pickle.load(file)
+    if isinstance(data, list):
+        data = np.array(data)
+    if data.dtype == np.float64 and FLOAT_POINT_SIZE == 32:
+        float32_data = data.astype(np.float32)
+        data = float32_data
+    assert(data.shape[1] == d)
+    return data
+
+
+def break_into_chunks(num_embeddings, chunk_size):
+    chunk_idxs = []
+    num_chunks = num_embeddings // chunk_size + 1 if num_embeddings % chunk_size != 0 else num_embeddings // chunk_size
+    remaining_embs_num = num_embeddings
+    for i in range(num_chunks):
+        start_idx = i*chunk_size
+        end_idx = i*chunk_size + min(chunk_size, remaining_embs_num)
+        chunk_idxs.append((start_idx, end_idx))
+        remaining_embs_num -= chunk_size
+    return chunk_idxs
+
+    
+def put_initial_embeddings_docs(capi, basepath):
+    # 0. put answer mapping
+    DOC_EMB_MAP = pickle.load(open(os.path.join(basepath, DOC_EMB_MAP_FILENAME), "rb"))
+    print("Initializing: putting doc_emb map to cascade server ...")
+    for i, (cluster_id, table_dict) in enumerate(DOC_EMB_MAP.items()):
+        # break the table into chunks
+        chunk_idx = break_into_chunks(len(table_dict), NUM_KEY_PER_MAP_OBJ)
+        table_key_list = list(table_dict.keys())
+        for j, (start_idx, end_idx) in enumerate(chunk_idx):
+            key = f"/rag/doc/emb_doc_map/cluster{cluster_id}/{j}"
+            table_dict_chunk = {k: table_dict[k] for k in table_key_list[start_idx:end_idx]}
+            table_json = json.dumps(table_dict_chunk)
+            res = capi.put(key, table_json.encode('utf-8'))
+            if res:
+                res.get_result()
+            else:
+                print(f"Failed to put the doc table to key: {key}")
+                exit(1)
+        print(f"         Put cluster{cluster_id} doc_emb_map size: {len(table_dict)}")
+    # 1. Put centroids'embeddings to cascade.
+    centroids_embs = get_embeddings(basepath, CENTROIDS_FILENAME, EMBEDDING_DIM)
+    centroids_chunk_idx = break_into_chunks(centroids_embs.shape[0], NUM_EMB_PER_OBJ)
+    print(f"Initilizing: put {centroids_embs.shape[0]} centroids embeddings to cascade")
+    for i, (start_idx, end_idx) in enumerate(centroids_chunk_idx):
+        key = f"/rag/emb/centroids_obj/{i}"
+        centroids_embs_chunk = centroids_embs[start_idx:end_idx]
+        res = capi.put(key, centroids_embs_chunk.tobytes())
+        if res:
+            res.get_result()
+        else:
+            print(f"Failed to put the centroids embeddings to key: {key}")
+            exit(1)
+    print("Initializing: putting clusters' embeddings and docs to cascade server ...")
+
+    #doc_list = pickle.load(open(os.path.join(basepath, DOC_LIST_FILENAME), "rb"))
+    # 2. Put clusters' embeddings and docs to cascade.
+    centroid_count = centroids_embs.shape[0]
+    cluster_file_name_list = [f'{CLUSTER_FILE_PREFIX}{count}.pkl' for count in range(centroid_count)]
+    for cluster_id, cluster_file_name in enumerate(cluster_file_name_list):
+        cluster_embs = get_embeddings(basepath, cluster_file_name, EMBEDDING_DIM)
+        num_embeddings = cluster_embs.shape[0]
+        cluster_chunk_idx = break_into_chunks(num_embeddings, NUM_EMB_PER_OBJ)
+        for i, (start_idx, end_idx) in enumerate(cluster_chunk_idx):
+            key = f"/rag/emb/cluster{cluster_id}/{i}"
+            cluster_embs_chunk = cluster_embs[start_idx:end_idx]
+            res = capi.put(key, cluster_embs_chunk.tobytes())
+            if res:
+                res.get_result()
+            else:
+                print(f"Failed to put the cluster embeddings to key: {key}")
+                exit(1)
+        # Put the corresponding docs to cascade
+        # for emb_idx in range(num_embeddings):
+        #     doc_idx = DOC_EMB_MAP[cluster_id][emb_idx]
+        #     doc_key = f"/rag/doc/{doc_idx}"
+        #     doc = doc_list[doc_idx]
+        #     res = capi.put(doc_key, doc.encode('utf-8'))
+        #     if res:
+        #         res.get_result()
+        #     else:
+        #         print(f"Failed to put the doc to key: {doc_key}")
+        #         exit(1)
+        print(f"         Put cluster{cluster_id}, num {num_embeddings} emb+doc, {len(cluster_chunk_idx)} objs to cascade")
+    print(f"Initialized embeddings")
+
+
+    
+
+
+def main(argv):
+    print("Connecting to Cascade service ...")
+    # get the datadir from the command line
+    if len(argv) < 2:
+        print("Usage: python3 perf_test_setup.py <path_to_data_folder>")
+        exit(1)
+    data_dir = argv[1]
+    capi = ServiceClientAPI()
+    create_object_pool(capi, script_dir)
+    put_initial_embeddings_docs(capi, data_dir)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/vortex_client/latency_client.cpp
+++ b/vortex_client/latency_client.cpp
@@ -111,6 +111,15 @@ bool deserialize_result(const Blob& blob, std::string& query_text, std::vector<s
           query_text = parsed_json["query"];
           top_k_docs = parsed_json["top_k_docs"];
 
+          // // Print the query_text
+          // std::cout << "Query: " << query_text << std::endl;
+
+          // // Print the contents of top_k_docs
+          // std::cout << "Top K Docs:" << std::endl;
+          // for (const auto& doc : top_k_docs) {
+          //   std::cout << doc << std::endl;
+          // }
+
      } catch (const nlohmann::json::parse_error& e) {
           std::cerr << "Result JSON parse error: " << e.what() << std::endl;
           return false;

--- a/vortex_client/recall_client.cpp
+++ b/vortex_client/recall_client.cpp
@@ -6,15 +6,38 @@
 #include <vector>
 
 using namespace derecho::cascade;
-#define EMBEDDING_DIM 1024
+
+//TODO: change these to read from dfgs json
+#define EMBEDDING_DIM 960
+#define TOP_K 5
 #define VORTEX_SUBGROUP_INDEX 0
 #define AGG_SUBGROUP_INDEX 0
 #define QUERY_FILENAME "query.csv"
 #define QUERY_EMB_FILENAME "query_emb.csv"
+#define GROUNDTRUTH_FILENAME "groundtruth.csv"
 
 // Use vector since one query may be reuse for multiple times
 std::unordered_map<std::string, std::vector<std::tuple<int, int>>> sent_queries;
-std::unordered_map<std::string, std::string> query_results;
+std::unordered_map<std::string, std::vector<std::string>> query_results;
+
+std::string get_doc_index_from_obj_path(std::string obj_path) {
+     std::string doc_index = obj_path.substr(obj_path.find_last_of('/') + 1);
+     return doc_index;
+}
+
+uint get_query_num(std::string obj_path) {
+     std::string doc_index = obj_path.substr(obj_path.find_last_of(' ') + 1);
+     return stoi(doc_index);
+}
+
+bool arr_contains(const std::string arr[], int size, const std::string& value) {
+    for (int i = 0; i < size; ++i) {
+        if (arr[i] == value) {
+            return true; // Found the value
+        }
+    }
+    return false; // Not found
+}
 
 int read_queries(std::filesystem::path query_filepath, int num_queries, int batch_size, std::vector<std::string>& queries) {
      std::ifstream file(query_filepath);
@@ -75,6 +98,38 @@ int read_query_embs(std::string query_emb_directory, int num_queries, int batch_
 }
 
 
+std::vector<std::vector<std::string>> read_groundtruth(std::filesystem::path filename) {
+    std::vector<std::vector<std::string>> data;
+    std::ifstream file(filename);
+
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open file " << filename << std::endl;
+        return data;
+    }
+
+    std::string line;
+    // Read the file line by line
+    while (std::getline(file, line)) {
+        std::vector<std::string> row;
+        std::stringstream line_stream(line);
+        std::string cell;
+
+        // Split each line by commas
+        while (std::getline(line_stream, cell, ',')) {
+            row.push_back(cell);
+        }
+        data.push_back(row);
+    }
+
+    file.close();
+    for (auto& row : data) {
+        if (row.size() > TOP_K) {
+            row.resize(TOP_K); // Keep only the first k elements
+        }
+    }
+    return data;
+}
+
 std::string format_query_emb_object(int nq, std::unique_ptr<float[]>& xq, std::vector<std::string>& query_list) {
      // create an bytes object by concatenating: num_queries + float array of emebddings + list of query_text
      uint32_t num_queries = static_cast<uint32_t>(nq);
@@ -119,7 +174,7 @@ bool deserialize_result(const Blob& blob, std::string& query_text, std::vector<s
 }
 
 
-bool run_latency_test(ServiceClientAPI& capi, int num_queries, int batch_size, std::string& query_directory, int query_interval) {
+bool run_recall_test(ServiceClientAPI& capi, int num_queries, int batch_size, std::string& query_directory, int query_interval) {
      int my_id = capi.get_my_id();
      // 1.1. Prepare for the notification by creating object pool for results to store
      std::string result_pool_name = "/rag/results/" + std::to_string(my_id);
@@ -140,7 +195,7 @@ bool run_latency_test(ServiceClientAPI& capi, int num_queries, int batch_size, s
                          return false;
                     }
                     if (query_results.find(query_text) == query_results.end()) {
-                         query_results[query_text] = top_k_docs[0];
+                         query_results[query_text] = top_k_docs;
                     }
                     if (sent_queries.find(query_text) != sent_queries.end()) {
                          for (auto& [qb_id, q_id]: sent_queries[query_text]) {
@@ -282,6 +337,39 @@ bool run_latency_test(ServiceClientAPI& capi, int num_queries, int batch_size, s
      }
      std::cout << "Flushed logs to shards." << std::endl;
      TimestampLogger::flush("client_timestamp.dat");
+
+
+     std::cout << "Compare with groundtruth:" << std::endl;
+     std::filesystem::path groundtruth_pathname = std::filesystem::path(query_directory) / GROUNDTRUTH_FILENAME;
+     std::vector<std::vector<std::string>> groundtruth = read_groundtruth(groundtruth_pathname);
+
+     for (const auto& [query, results] : query_results) {
+        
+          std::cout << "Query: " << query << std::endl;
+          uint query_index = get_query_num(query);
+          std::cout << "Results:" << std::endl;
+
+          uint total = 0;
+          uint found = 0;
+          for (const auto& result : results) {
+                total++;
+               std::string doc_index = get_doc_index_from_obj_path(result);
+               if(arr_contains(groundtruth[query_index].data(), TOP_K, doc_index)) {
+                    found++;
+               }
+               std::cout << get_doc_index_from_obj_path(result) << std::endl;
+          }
+          if (query_index < groundtruth.size()) {
+            std::cout << "Groundtruth:" << std::endl;
+            for (const auto& gt : groundtruth[query_index]) {
+                std::cout << gt << std::endl;
+            }
+        }
+          std::cout << "Recall: " << static_cast<double>(found) / total << std::endl;
+          std::cout << "------------------------" << std::endl;
+     }
+     //TODO: compare groundtruth with results
+
      return true;
 }
 
@@ -326,7 +414,7 @@ int main(int argc, char** argv){
      std::cout << "Batch size: " << batch_size << std::endl;
 
      auto& capi = ServiceClientAPI::get_service_client();
-     run_latency_test(capi, num_queries, batch_size, query_directory, query_interval);
+     run_recall_test(capi, num_queries, batch_size, query_directory, query_interval);
 
      return 0;
 }

--- a/vortex_udls/aggregate_generate_udl.cpp
+++ b/vortex_udls/aggregate_generate_udl.cpp
@@ -239,8 +239,8 @@ class AggGenOCDPO: public DefaultOffCriticalDataPathObserver {
         // 3. All cluster results are collected for this query, aggregate the top_k results
         auto& agg_top_k_results = query_results[query_text]->agg_top_k_results;
         // 4. get the top_k docs content
-        std::vector<std::string> top_k_docs(top_k);
-        uint i = top_k - 1;
+        std::vector<std::string> top_k_docs(agg_top_k_results.size());
+        uint i = agg_top_k_results.size() - 1;
         while (!agg_top_k_results.empty()) {
             auto doc_index = agg_top_k_results.top();
             agg_top_k_results.pop();

--- a/vortex_udls/clusters_search_udl.cpp
+++ b/vortex_udls/clusters_search_udl.cpp
@@ -150,7 +150,6 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
         TimestampLogger::log(LOG_CLUSTER_SEARCH_FAISS_SEARCH_END,client_id,query_batch_id,cluster_id);
 #endif
         dbg_default_trace("[Cluster search ocdpo] Finished knn search for key: {}.", key_string);
-        
 
         // 4. emit the results to the subsequent UDL query-by-query
         // 4.1 construct new keys for all queries in this search


### PR DESCRIPTION
- V0 of recall client called recall_client.cpp
- code to download GIST dataset and format it for testing use in Vortex. Only thing missing here is generating the centroids but will add this later. For now it just makes 1 centroid and 1 cluster
- added flag in aggreagate_generate UDL to skip retrieving the documents and instead just return the path which includes the doc index if desired. This makes testing a lot faster for 1m+ size datasets because we won't have to wait 30+ mins to insert all the documents into cascade and instead have to wait only 30 seconds for the embeddings chunks to insert
- aggregate generate UDL was previously returning the top_k documents to the client in reverse order, so I edited it to return them ordered correctly