### PR TITLE
New client implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,15 @@ set(LOG_TAG_QUERIES_SENDING_START 10000)
 set(LOG_TAG_QUERIES_SENDING_END 10001)
 set(LOG_TAG_QUERIES_RESULT_CLIENT_RECEIVED 10100)
 
+add_executable(run_benchmark benchmark/benchmark_client.cpp benchmark/run_benchmark.cpp benchmark/benchmark_dataset.cpp)
+target_link_libraries(run_benchmark derecho::cascade)
+target_compile_definitions(run_benchmark PRIVATE
+    LOG_TAG_QUERIES_SENDING_START=${LOG_TAG_QUERIES_SENDING_START}
+    LOG_TAG_QUERIES_SENDING_END=${LOG_TAG_QUERIES_SENDING_END}
+    LOG_TAG_QUERIES_RESULT_CLIENT_RECEIVED=${LOG_TAG_QUERIES_RESULT_CLIENT_RECEIVED}
+    ENABLE_VORTEX_EVALUATION_LOGGING=${ENABLE_VORTEX_EVALUATION_LOGGING}
+)
+
 add_executable(latency_client benchmark/vortex_client.cpp benchmark/latency_client.cpp vortex_udls/rag_utils.cpp)
 target_link_libraries(latency_client PRIVATE libwsong::perf derecho derecho::cascade pthread OpenSSL::Crypto)
 target_compile_definitions(latency_client PRIVATE

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ The object pools needed for this pipeline: /rag/emb, /rag/doc, /rag/generate. Th
 Construct the vector database by putting centroids and clusters' embeddings and documents.
 
 #### Vector database Data Storage formats
-- embeddings: stored in /rag/emb object pool
+- embeddings: stored in /rag/emb/* object pools
 
 centroids stored in the format of /rag/emb/centroids_obj/[obj_id], e.g. /rag/emb/centroids_obj/1, /rag/emb/centroids_obj/2
 
-cluster embeddings stored in the format of /rag/emb/cluster[cluster_id]/[obj_id], e.g. /rag/emb/cluster1/0, /rag/emb/cluster2/0
+cluster embeddings stored in the format of /rag/emb/clusters/cluster[cluster_id]/[obj_id], e.g. /rag/emb/clusters/cluster1/0, /rag/emb/clusters/cluster2/0
 
 Note that because we use these keys as identifier to the embeddings object, if accidentally put other objects with the same prefix put to Cascade, it could cause unexpected knn search result. 
 

--- a/benchmark/benchmark_client.cpp
+++ b/benchmark/benchmark_client.cpp
@@ -16,7 +16,28 @@ VortexBenchmarkClient::~VortexBenchmarkClient(){
         t.join();
     }
 
-    // TODO print batching statistics
+    // print batching statistics
+    std::cout << "batching statistics:" << std::endl;
+    std::vector<uint64_t> values;
+    values.reserve(client_thread->batch_size.size());
+    double sum = 0.0;
+    for(const auto& [batch_id, sz] : client_thread->batch_size){
+        values.push_back(sz);
+        sum += sz;
+    }
+
+    double avg = sum / client_thread->batch_size.size();
+    std::sort(values.begin(),values.end());
+    auto min = values.front();
+    auto max = values.back();
+    auto median = values[values.size()/2];
+    auto p95 = values[(uint64_t)(values.size()*0.95)];
+
+    std::cout << "  avg: " << avg << std::endl;
+    std::cout << "  median: " << median << std::endl;
+    std::cout << "  min: " << min << std::endl;
+    std::cout << "  max: " << max << std::endl;
+    std::cout << "  p95: " << p95 << std::endl;
 }
 
 void VortexBenchmarkClient::setup(uint64_t batch_min_size,uint64_t batch_max_size,uint64_t batch_time_us,uint64_t emb_dim,uint64_t num_result_threads){

--- a/benchmark/benchmark_client.cpp
+++ b/benchmark/benchmark_client.cpp
@@ -1,0 +1,286 @@
+
+#include "benchmark_client.hpp"
+
+VortexBenchmarkClient::VortexBenchmarkClient(){
+}
+
+VortexBenchmarkClient::~VortexBenchmarkClient(){
+    client_thread->signal_stop();
+    client_thread->join();
+
+    notification_thread->signal_stop();
+    notification_thread->join();
+
+    // TODO print batching statistics
+}
+
+void VortexBenchmarkClient::setup(uint64_t batch_min_size,uint64_t batch_max_size,uint64_t batch_time_us,uint64_t emb_dim){
+    this->emb_dim = emb_dim;
+
+    // Prepare for the notification by creating object pool for results to store
+    std::string result_pool_name = "/rag/results/" + std::to_string(this->my_id);
+    std::cout << "  creating object pool for receiving results: " << result_pool_name << std::endl;
+    auto res = capi.template create_object_pool<UDLS_SUBGROUP_TYPE>(result_pool_name,UDL3_SUBGROUP_INDEX,HASH,{});
+    for (auto& reply_future:res.get()) {
+        reply_future.second.get(); // wait for the object pool to be created
+    }
+
+    // Register notification for this object pool
+    std::cout << "  registering notification handler ... " << result_pool_name << std::endl;
+    bool ret = capi.register_notification_handler(
+            [&](const Blob& result){
+                notification_thread->push_result(result);
+                return true;
+            }, result_pool_name);
+
+    // Establish connections to all server nodes running UDL3
+    auto shards = capi.get_subgroup_members<UDLS_SUBGROUP_TYPE>(UDL3_SUBGROUP_INDEX);
+    std::cout << "  pre-establishing connections with all nodes in " << shards.size() << " shards ..." << std::endl;
+    ObjectWithStringKey obj;
+    obj.key = "establish_connection";
+    std::string control_value = "establish";
+    obj.blob = Blob(reinterpret_cast<const uint8_t*>(control_value.c_str()), control_value.size());
+    uint32_t i = 0;
+    for(auto& shard : shards){
+        for(int j=0;j<shard.size();j++){
+            // each iteration reaches a different node in the shard due to the round robin policy
+            auto res = capi.template put<UDLS_SUBGROUP_TYPE>(obj, UDL3_SUBGROUP_INDEX, i, true);
+            for (auto& reply_future:res.get()) {
+                reply_future.second.get(); // wait for the object has been put
+            }
+        }
+        i++;
+    }
+
+    // start notification thread
+    notification_thread = new NotificationThread(this);
+    notification_thread->start();
+
+    // start client thread
+    client_thread = new ClientThread(batch_min_size,batch_max_size,batch_time_us,emb_dim);
+    client_thread->start();
+}
+
+query_id_t VortexBenchmarkClient::next_query_id(){
+    std::unique_lock<std::mutex> lock(query_id_mtx);
+    query_id_t query_id = (my_id << 48) | query_count;
+    query_count++;
+    return query_id;
+}
+
+uint64_t VortexBenchmarkClient::query(const std::string& query,const float* query_emb){
+    query_id_t query_id = VortexBenchmarkClient::next_query_id();
+    queued_query_t new_query(query_id,&query,query_emb);
+    client_thread->push_query(new_query);
+    return query_id;
+}
+
+void VortexBenchmarkClient::wait_results(){
+    std::cout << "  received " << result_count << std::endl;
+    uint64_t wait_time = 0;
+    while(result_count < query_count){
+        if(wait_time >= VORTEX_CLIENT_MAX_WAIT_TIME){
+            std::cout << "  waited more than " << VORTEX_CLIENT_MAX_WAIT_TIME << " seconds, stopping ..." << std::endl;
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::cout << "  received " << result_count << std::endl;
+        wait_time += 2;
+    }
+}
+
+void VortexBenchmarkClient::dump_timestamps(){
+    TimestampLogger::flush("client" + std::to_string(my_id) + ".dat");
+    capi.dump_timestamp(UDL1_TIMESTAMP_FILE,UDL1_PATH);
+    capi.dump_timestamp(UDL2_TIMESTAMP_FILE,UDL2_PATH);
+    capi.dump_timestamp(UDL3_TIMESTAMP_FILE,UDL3_PATH);
+}
+
+void VortexBenchmarkClient::result_received(nlohmann::json &result_json){
+    uint32_t batch_id = (int)result_json["query_batch_id"] / QUERY_BATCH_ID_MODULUS; // TODO this is weird: we should use a global unique identifier for each individual query
+    std::string query_text(std::move(result_json["query"]));
+    auto index_and_id = client_thread->batched_query_to_index_and_id[batch_id][query_text];
+    uint64_t query_index = index_and_id.first;
+    query_id_t query_id = index_and_id.second;
+
+    result.emplace(query_id,std::move(result_json["top_k_docs"]));
+    
+    TimestampLogger::log(LOG_TAG_QUERIES_RESULT_CLIENT_RECEIVED,my_id,batch_id,query_index);
+    result_count++;
+}
+
+const std::vector<std::string>& VortexBenchmarkClient::get_result(query_id_t query_id){
+    return result[query_id];
+}
+
+// client thread methods
+
+VortexBenchmarkClient::ClientThread::ClientThread(uint64_t batch_min_size,uint64_t batch_max_size,uint64_t batch_time_us,uint64_t emb_dim){
+    this->batch_min_size = batch_min_size;
+    this->batch_max_size = batch_max_size;
+    this->batch_time_us = batch_time_us;
+    this->emb_dim = emb_dim;
+}
+
+void VortexBenchmarkClient::ClientThread::push_query(queued_query_t &queued_query){
+    std::unique_lock<std::mutex> lock(thread_mtx);
+    query_queue.push(queued_query);
+    thread_signal.notify_all();
+}
+
+void VortexBenchmarkClient::ClientThread::signal_stop(){
+    std::unique_lock<std::mutex> lock(thread_mtx);
+    running = false;
+    thread_signal.notify_all();
+}
+
+// helper function
+void inline build_batch_string(std::string& batch_string,queued_query_t* to_send,uint64_t send_count,uint64_t emb_dim){
+    // TODO this seems inefficient, but since it is not the bottleneck, we can leave it this way for now
+
+    // create an bytes object by concatenating: num_queries + float array of embeddings + list of query_text
+    batch_string.reserve(sizeof(uint32_t) + (send_count * sizeof(float) * emb_dim) + (send_count * 200));
+    
+    uint32_t num_queries = static_cast<uint32_t>(send_count);
+    std::string nq_bytes(4, '\0');
+    nq_bytes[0] = (num_queries >> 24) & 0xFF;
+    nq_bytes[1] = (num_queries >> 16) & 0xFF;
+    nq_bytes[2] = (num_queries >> 8) & 0xFF;
+    nq_bytes[3] = num_queries & 0xFF;
+    batch_string += nq_bytes;
+
+    std::vector<std::string> query_list;
+    query_list.reserve(num_queries);
+    for(uint32_t i=0;i<num_queries;i++){
+        batch_string.append(reinterpret_cast<const char*>(std::get<2>(to_send[i])),sizeof(float) * emb_dim);
+        query_list.push_back(*std::get<1>(to_send[i]));
+    }
+
+    batch_string += nlohmann::json(query_list).dump();
+}
+
+void VortexBenchmarkClient::ClientThread::main_loop(){
+    if(!running) return;
+    
+    // thread main loop
+    queued_query_t to_send[batch_max_size];
+    auto wait_start = std::chrono::steady_clock::now();
+    auto batch_time = std::chrono::microseconds(batch_time_us);
+    uint32_t batch_id = 0;
+    while(true){
+        std::unique_lock<std::mutex> lock(thread_mtx);
+        if(query_queue.empty()){
+            thread_signal.wait_for(lock,batch_time);
+        }
+
+        if(!running) break;
+
+        uint64_t send_count = 0;
+        uint64_t queued_count = query_queue.size();
+        auto now = std::chrono::steady_clock::now();
+
+        if((queued_count >= batch_min_size) || ((now-wait_start) >= batch_time)){
+            send_count = std::min(queued_count,batch_max_size);
+            wait_start = now;
+
+            // copy out queries
+            for(uint64_t i=0;i<send_count;i++){
+                to_send[i] = query_queue.front();
+                query_queue.pop();
+            }
+        }
+
+        lock.unlock();
+
+        // now we are outside the locked region (i.e the client can continue adding queries to the queue): build object and call trigger_put
+        if(send_count > 0){
+            ObjectWithStringKey obj;
+            obj.key = "/rag/emb/centroids_search/client" + std::to_string(node_id) + "/qb" + std::to_string(batch_id);
+
+            // build Blob from queries in to_send
+            std::string batch_string;
+            build_batch_string(batch_string,to_send,send_count,emb_dim);
+            obj.blob = Blob(reinterpret_cast<const uint8_t*>(batch_string.c_str()), batch_string.size());
+            
+            for(uint64_t i=0;i<send_count;i++){
+                auto query_id = std::get<0>(to_send[i]);
+                // TODO this is inefficient: we should use just query_id (but this requires chaning the UDLs to carry query_id around)
+                batched_query_to_index_and_id[batch_id][*std::get<1>(to_send[i])] = std::make_pair(i,query_id);
+                TimestampLogger::log(LOG_TAG_QUERIES_SENDING_START,node_id,batch_id,i);
+            }
+
+            // trigger put
+            capi.trigger_put(obj);
+            
+            for(uint64_t i=0;i<send_count;i++){
+                TimestampLogger::log(LOG_TAG_QUERIES_SENDING_END,node_id,batch_id,i);
+            }
+
+            batch_size[batch_id] = send_count; // for statistics
+            batch_id++;
+        }
+    }
+}
+
+// notification thread methods
+
+VortexBenchmarkClient::NotificationThread::NotificationThread(VortexBenchmarkClient* vortex){
+    this->vortex = vortex;
+}
+
+void VortexBenchmarkClient::NotificationThread::push_result(const Blob& result){
+    std::unique_lock<std::mutex> lock(thread_mtx);
+    to_process.emplace(result);
+    thread_signal.notify_all();
+}
+
+void VortexBenchmarkClient::NotificationThread::signal_stop(){
+    std::unique_lock<std::mutex> lock(thread_mtx);
+    running = false;
+    thread_signal.notify_all();
+}
+
+void VortexBenchmarkClient::NotificationThread::main_loop(){
+    if(!running) return;
+    
+    // thread main loop
+    while(true){
+        std::unique_lock<std::mutex> lock(thread_mtx);
+        if(to_process.empty()){
+            thread_signal.wait(lock);
+        }
+
+        if(!running) break;
+
+        Blob blob(std::move(to_process.front()));
+        to_process.pop();
+        lock.unlock();
+        
+        // deserialize the JSON
+        // TODO why JSON?
+       
+        if (blob.size == 0) {
+             std::cerr << "Error: empty result blob." << std::endl;
+             continue;
+        }
+
+        char* json_data = const_cast<char*>(reinterpret_cast<const char*>(blob.bytes));
+        std::size_t json_size = blob.size;
+        std::string json_string(json_data, json_size);
+
+        try{
+             nlohmann::json parsed_json = nlohmann::json::parse(json_string);
+             if (parsed_json.count("query") == 0 || parsed_json.count("top_k_docs") == 0) {
+                  std::cerr << "Result JSON does not contain query or top_k_docs." << std::endl;
+                  continue;
+             }
+
+             vortex->result_received(parsed_json);
+        } catch (const nlohmann::json::parse_error& e) {
+             std::cerr << "Result JSON parse error: " << e.what() << std::endl;
+             continue;
+        }
+    }
+}
+

--- a/benchmark/benchmark_client.hpp
+++ b/benchmark/benchmark_client.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <cascade/service_client_api.hpp>
+#include <string>
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <shared_mutex>
+#include <queue>
+#include <iostream>
+#include <tuple>
+#include <atomic>
+#include <unordered_map>
+#include "../vortex_udls/rag_utils.hpp"
+
+using namespace derecho::cascade;
+
+#define UDL1_PATH "/rag/emb/centroids_search"
+#define UDL2_PATH "/rag/emb/clusters_search"
+#define UDL3_PATH "/rag/generate/agg"
+#define UDL1_TIMESTAMP_FILE "udl1.dat"
+#define UDL2_TIMESTAMP_FILE "udl2.dat"
+#define UDL3_TIMESTAMP_FILE "udl3.dat"
+#define UDL1_SUBGROUP_INDEX 0
+#define UDL2_SUBGROUP_INDEX 1
+#define UDL3_SUBGROUP_INDEX 2
+#define UDLS_SUBGROUP_TYPE VolatileCascadeStoreWithStringKey 
+
+#define VORTEX_CLIENT_MAX_WAIT_TIME 60
+
+using query_id_t = uint64_t; 
+using queued_query_t = std::tuple<query_id_t,const std::string*,const float*>;
+
+class VortexBenchmarkClient {
+    /*
+     * This thread is responsible for batching queries and sending them to the first UDL in the pipeline (using trigger_put).
+     */
+    class ClientThread {
+    private:
+        std::thread real_thread;
+        ServiceClientAPI& capi = ServiceClientAPI::get_service_client();
+        uint64_t node_id = capi.get_my_id();
+        uint64_t batch_min_size = 0;
+        uint64_t batch_max_size = 5;
+        uint64_t batch_time_us = 500;
+        uint64_t emb_dim = 1024;
+
+        bool running = false;
+        std::mutex thread_mtx;
+        std::condition_variable thread_signal;
+
+        std::queue<queued_query_t> query_queue;
+
+        void main_loop();
+
+    public:
+        ClientThread(uint64_t batch_min_size,uint64_t batch_max_size,uint64_t batch_time_us,uint64_t emb_dim);
+        void push_query(queued_query_t &queued_query);
+        void signal_stop();
+        std::unordered_map<uint32_t,uint64_t> batch_size;
+
+        // TODO this is inefficient: we should use a global identifier (query_id_t) for each query and send it through the pipeline, so it's easy to identify them later when the results come back
+        std::unordered_map<uint32_t,std::unordered_map<std::string,std::pair<uint64_t,query_id_t>>> batched_query_to_index_and_id;
+
+        inline void start(){
+            running = true;
+            real_thread = std::thread(&ClientThread::main_loop,this);
+        }
+
+        inline void join(){
+            real_thread.join();
+        }
+    };
+
+    /*
+     * This thread is responsible for deserializing results received by the last UDL in the pipeline.
+     */
+    class NotificationThread {
+    private:
+        std::thread real_thread;
+        bool running = false;
+        std::mutex thread_mtx;
+        std::condition_variable thread_signal;
+
+        std::queue<Blob> to_process;
+        VortexBenchmarkClient* vortex;
+
+        void main_loop();
+
+    public:
+        NotificationThread(VortexBenchmarkClient* vortex);
+        void push_result(const Blob& result);
+        void signal_stop();
+
+        inline void start(){
+            running = true;
+            real_thread = std::thread(&NotificationThread::main_loop,this);
+        }
+
+        inline void join(){
+            real_thread.join();
+        }
+    };
+
+    ServiceClientAPI& capi = ServiceClientAPI::get_service_client();
+    uint64_t my_id = capi.get_my_id();
+    ClientThread *client_thread;
+    NotificationThread *notification_thread;
+    uint64_t emb_dim = 1024;
+
+    std::mutex query_id_mtx;
+    uint64_t query_count = 0;
+    query_id_t next_query_id();
+
+    std::atomic<uint64_t> result_count = 0;
+
+    std::unordered_map<query_id_t,std::vector<std::string>> result;
+    void result_received(nlohmann::json &result_json);
+
+    public:
+
+    VortexBenchmarkClient();
+    ~VortexBenchmarkClient();
+    
+    void setup(uint64_t batch_min_size,uint64_t batch_max_size,uint64_t batch_time_us,uint64_t emb_dim);
+   
+    uint64_t query(const std::string& query,const float* query_emb);
+    void wait_results();
+    const std::vector<std::string>& get_result(query_id_t query_id);
+    void dump_timestamps();
+};
+

--- a/benchmark/benchmark_client.hpp
+++ b/benchmark/benchmark_client.hpp
@@ -58,10 +58,10 @@ class VortexBenchmarkClient {
         ClientThread(uint64_t batch_min_size,uint64_t batch_max_size,uint64_t batch_time_us,uint64_t emb_dim);
         void push_query(queued_query_t &queued_query);
         void signal_stop();
-        std::unordered_map<uint32_t,uint64_t> batch_size;
+        std::unordered_map<uint64_t,uint64_t> batch_size;
 
         // TODO this is inefficient: we should use a global identifier (query_id_t) for each query and send it through the pipeline, so it's easy to identify them later when the results come back
-        std::unordered_map<uint32_t,std::unordered_map<std::string,std::pair<uint64_t,query_id_t>>> batched_query_to_index_and_id;
+        std::unordered_map<uint64_t,std::unordered_map<std::string,std::pair<uint64_t,query_id_t>>> batched_query_to_index_and_id;
         std::shared_mutex map_mutex;
 
         inline void start(){
@@ -131,6 +131,6 @@ class VortexBenchmarkClient {
     uint64_t query(const std::string& query,const float* query_emb);
     void wait_results();
     const std::vector<std::string>& get_result(query_id_t query_id);
-    void dump_timestamps();
+    void dump_timestamps(bool dump_remote = true);
 };
 

--- a/benchmark/benchmark_dataset.cpp
+++ b/benchmark/benchmark_dataset.cpp
@@ -1,0 +1,95 @@
+#include "benchmark_dataset.hpp"
+
+VortexBenchmarkDataset::VortexBenchmarkDataset(const std::string& dataset_dir,uint64_t num_queries,uint64_t emb_dim){
+    this->dataset_dir = dataset_dir;
+    this->emb_dim = emb_dim;
+
+    read_queries(num_queries);
+    read_query_embs();
+    read_groundtruth();
+}
+
+uint64_t VortexBenchmarkDataset::get_next_query_index(){
+    auto query_index = next_query;
+    next_query++;
+    return query_index;
+}
+
+const std::string& VortexBenchmarkDataset::get_query(uint64_t query_index){
+    return queries[query_index % queries.size()];
+}
+
+const float* VortexBenchmarkDataset::get_embeddings(uint64_t query_index){
+    return query_embs[query_index % query_embs.size()];
+}
+
+const std::vector<std::string>& VortexBenchmarkDataset::get_groundtruth(uint64_t query_index){
+    return query_groundtruth[query_index % query_groundtruth.size()];
+}
+
+void VortexBenchmarkDataset::read_queries(uint64_t num_queries){
+    std::filesystem::path query_filepath = std::filesystem::path(dataset_dir) / QUERY_FILENAME;
+
+    std::ifstream file(query_filepath);
+    if (!file.is_open()) {
+        std::cerr << "  Error: Could not open query directory:" << query_filepath << std::endl;
+        std::cerr << "  Current only support query_doc in csv format." << std::endl;
+        return;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if(queries.size() >= num_queries){
+            break;
+        }
+        queries.push_back(line);
+    }
+
+    file.close();
+}
+
+void VortexBenchmarkDataset::read_query_embs(){
+    std::filesystem::path query_emb_filepath = std::filesystem::path(dataset_dir) / QUERY_EMB_FILENAME;
+    query_embs.reserve(queries.size());
+
+    std::ifstream file(query_emb_filepath);
+    if (!file.is_open()) {
+        std::cerr << "  Error: Could not open query directory:" << query_emb_filepath << std::endl;
+        std::cerr << "  Current only support query_doc in csv format." << std::endl;
+        return;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if(query_embs.size() >= queries.size()){
+            break;
+        }
+
+        float *embs = new float[emb_dim];
+        std::istringstream ss(line);
+        std::string token;
+        int i = 0;
+        while (std::getline(ss, token, ',')) {
+            embs[i] = std::stof(token);
+            i++;
+        }
+
+        if (i != emb_dim) {
+            std::cerr << "  Error: query embedding dimension does not match." << std::endl;
+            return;
+        }
+
+        query_embs.push_back(embs);
+    }
+
+    file.close();
+
+    if(query_embs.size() < queries.size()){
+        std::cerr << "  Warning: number of embeddings (" << query_embs.size() << ") is smaller than number of queries (" << queries.size() << ")" << std::endl;
+    }
+}
+
+void VortexBenchmarkDataset::read_groundtruth(){
+    // TODO
+}
+

--- a/benchmark/benchmark_dataset.cpp
+++ b/benchmark/benchmark_dataset.cpp
@@ -90,6 +90,27 @@ void VortexBenchmarkDataset::read_query_embs(){
 }
 
 void VortexBenchmarkDataset::read_groundtruth(){
-    // TODO
+    std::filesystem::path filename = std::filesystem::path(dataset_dir) / GROUNDTRUTH_FILENAME; 
+    
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        std::cerr << "  No groundtruth file found!" << std::endl;
+        groundtruth_loaded = false;
+        return;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        std::vector<std::string> row;
+        std::stringstream line_stream(line);
+        std::string cell;
+        while (std::getline(line_stream, cell, ',')) {
+            row.push_back(cell);
+        }
+        query_groundtruth.push_back(row);
+    }
+
+    file.close();
+    groundtruth_loaded = true;
 }
 

--- a/benchmark/benchmark_dataset.hpp
+++ b/benchmark/benchmark_dataset.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <tuple>
+#include <filesystem>
+#include <iostream>
+#include <fstream>
+
+#define QUERY_FILENAME "query.csv"
+#define QUERY_EMB_FILENAME "query_emb.csv"
+#define GROUNDTRUTH_FILENAME "groundtruth.csv"
+
+class VortexBenchmarkDataset {
+    void read_queries(uint64_t num_queries);
+    void read_query_embs();
+    void read_groundtruth();
+
+    uint64_t next_query = 0;
+    uint64_t emb_dim = 1024;
+    std::string dataset_dir;
+    std::vector<std::string> queries;
+    std::vector<float*> query_embs;
+    std::vector<std::vector<std::string>> query_groundtruth;
+
+    public:
+        VortexBenchmarkDataset(const std::string& dataset_dir,uint64_t num_queries,uint64_t emb_dim);
+        
+        uint64_t get_next_query_index();
+        void reset(){ next_query = 0; }
+
+        const std::vector<std::string>& get_groundtruth(uint64_t query_index);
+        const std::string& get_query(uint64_t query_index);
+        const float* get_embeddings(uint64_t query_index);
+};
+

--- a/benchmark/benchmark_dataset.hpp
+++ b/benchmark/benchmark_dataset.hpp
@@ -18,6 +18,7 @@ class VortexBenchmarkDataset {
 
     uint64_t next_query = 0;
     uint64_t emb_dim = 1024;
+    bool groundtruth_loaded = false;
     std::string dataset_dir;
     std::vector<std::string> queries;
     std::vector<float*> query_embs;
@@ -28,6 +29,7 @@ class VortexBenchmarkDataset {
         
         uint64_t get_next_query_index();
         void reset(){ next_query = 0; }
+        bool has_groundtruth(){ return groundtruth_loaded; }
 
         const std::vector<std::string>& get_groundtruth(uint64_t query_index);
         const std::string& get_query(uint64_t query_index);

--- a/benchmark/run_benchmark.cpp
+++ b/benchmark/run_benchmark.cpp
@@ -23,6 +23,7 @@ void print_help(const std::string& bin_name){
     std::cout << " -x <batch_max_size>\t\tmaximum batch size (default: " << DEFAULT_BATCH_MAX_SIZE << ")" << std::endl;
     std::cout << " -u <batch_time_us>\t\tmaximum time to wait for the batch minimum size, in microseconds (default: " << DEFAULT_BATCH_TIME_US << ")" << std::endl;
     std::cout << " -t <num_result_threads>\tnumber of threads for processing results (default: " << DEFAULT_NUM_RESULT_THREADS << ")" << std::endl;
+    std::cout << " -d\t\t\t\tdo not dump timestamps in the remote servers (default: true)" << std::endl;
     std::cout << " -h\t\t\t\tshow this help" << std::endl;
 }
 
@@ -36,8 +37,9 @@ int main(int argc, char** argv){
     uint64_t num_queries = DEFAULT_NUM_QUERIES;
     uint64_t emb_dim = DEFAULT_DIMENSIONS;
     uint64_t num_result_threads = DEFAULT_NUM_RESULT_THREADS;
+    bool dump = true;
 
-    while ((c = getopt(argc, argv, "n:e:r:b:x:u:t:h")) != -1){
+    while ((c = getopt(argc, argv, "n:e:r:b:x:u:t:dh")) != -1){
         switch(c){
             case 'n':
                 num_queries = strtoul(optarg,NULL,10);
@@ -59,6 +61,9 @@ int main(int argc, char** argv){
                 break;
             case 't':
                 num_result_threads = strtoul(optarg,NULL,10);
+                break;
+            case 'd':
+                dump = false;
                 break;
             case '?':
             case 'h':
@@ -88,6 +93,7 @@ int main(int argc, char** argv){
     std::cout << "  batch_max_size = " << batch_max_size << std::endl;
     std::cout << "  batch_time_us = " << batch_time_us << std::endl;
     std::cout << "  num_result_threads = " << num_result_threads << std::endl;
+    std::cout << "  dump = " << dump << std::endl;
     std::cout << "  dataset_dir = " << dataset_dir << std::endl;
 
     VortexBenchmarkDataset dataset(dataset_dir,num_queries,emb_dim);
@@ -137,7 +143,7 @@ int main(int argc, char** argv){
 
     // write timestamps
     std::cout << "dumping timestamps ..." << std::endl;
-    vortex.dump_timestamps();
+    vortex.dump_timestamps(dump);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     return 0;

--- a/benchmark/run_benchmark.cpp
+++ b/benchmark/run_benchmark.cpp
@@ -11,17 +11,19 @@
 #define DEFAULT_BATCH_TIME_US 500
 #define DEFAULT_DIMENSIONS 1024
 #define DEFAULT_NUM_QUERIES 10
+#define DEFAULT_NUM_RESULT_THREADS 1
 
 void print_help(const std::string& bin_name){
     std::cout << "usage: " << bin_name << " [options] <dataset_dir>" << std::endl;
     std::cout << "options:" << std::endl;
-    std::cout << " -n <num_queries>\ttotal number of queries to send (default: " << DEFAULT_NUM_QUERIES << ")" << std::endl;
-    std::cout << " -e <emb_dim>\t\tembeddings dimensions (default: " << DEFAULT_DIMENSIONS << ")" << std::endl;
-    std::cout << " -r <send_rate>\t\trate (in queries/second) at which to send queries (default: unlimited)" << std::endl;
-    std::cout << " -b <batch_min_size>\tminimum batch size (default: " << DEFAULT_BATCH_MIN_SIZE << ")" << std::endl;
-    std::cout << " -x <batch_max_size>\tmaximum batch size (default: " << DEFAULT_BATCH_MAX_SIZE << ")" << std::endl;
-    std::cout << " -u <batch_time_us>\tmaximum time to wait for the batch minimum size, in microseconds (default: " << DEFAULT_BATCH_TIME_US << ")" << std::endl;
-    std::cout << " -h\t\t\tshow this help" << std::endl;
+    std::cout << " -n <num_queries>\t\ttotal number of queries to send (default: " << DEFAULT_NUM_QUERIES << ")" << std::endl;
+    std::cout << " -e <emb_dim>\t\t\tembeddings dimensions (default: " << DEFAULT_DIMENSIONS << ")" << std::endl;
+    std::cout << " -r <send_rate>\t\t\trate (in queries/second) at which to send queries (default: unlimited)" << std::endl;
+    std::cout << " -b <batch_min_size>\t\tminimum batch size (default: " << DEFAULT_BATCH_MIN_SIZE << ")" << std::endl;
+    std::cout << " -x <batch_max_size>\t\tmaximum batch size (default: " << DEFAULT_BATCH_MAX_SIZE << ")" << std::endl;
+    std::cout << " -u <batch_time_us>\t\tmaximum time to wait for the batch minimum size, in microseconds (default: " << DEFAULT_BATCH_TIME_US << ")" << std::endl;
+    std::cout << " -t <num_result_threads>\tnumber of threads for processing results (default: " << DEFAULT_NUM_RESULT_THREADS << ")" << std::endl;
+    std::cout << " -h\t\t\t\tshow this help" << std::endl;
 }
 
 int main(int argc, char** argv){
@@ -33,8 +35,9 @@ int main(int argc, char** argv){
     uint64_t batch_time_us = DEFAULT_BATCH_TIME_US;
     uint64_t num_queries = DEFAULT_NUM_QUERIES;
     uint64_t emb_dim = DEFAULT_DIMENSIONS;
+    uint64_t num_result_threads = DEFAULT_NUM_RESULT_THREADS;
 
-    while ((c = getopt(argc, argv, "n:e:r:b:x:u:h")) != -1){
+    while ((c = getopt(argc, argv, "n:e:r:b:x:u:t:h")) != -1){
         switch(c){
             case 'n':
                 num_queries = strtoul(optarg,NULL,10);
@@ -53,6 +56,9 @@ int main(int argc, char** argv){
                 break;
             case 'u':
                 batch_time_us = strtoul(optarg,NULL,10);
+                break;
+            case 't':
+                num_result_threads = strtoul(optarg,NULL,10);
                 break;
             case '?':
             case 'h':
@@ -81,6 +87,7 @@ int main(int argc, char** argv){
     std::cout << "  batch_min_size = " << batch_min_size << std::endl;
     std::cout << "  batch_max_size = " << batch_max_size << std::endl;
     std::cout << "  batch_time_us = " << batch_time_us << std::endl;
+    std::cout << "  num_result_threads = " << num_result_threads << std::endl;
     std::cout << "  dataset_dir = " << dataset_dir << std::endl;
 
     VortexBenchmarkDataset dataset(dataset_dir,num_queries,emb_dim);
@@ -88,7 +95,7 @@ int main(int argc, char** argv){
 
     // setup
     std::cout << "setting up client ..." << std::endl;
-    vortex.setup(batch_min_size,batch_max_size,batch_time_us,emb_dim);
+    vortex.setup(batch_min_size,batch_max_size,batch_time_us,emb_dim,num_result_threads);
 
     // send queries
     std::cout << "sending " << num_queries << " queries ..." << std::endl;

--- a/benchmark/run_benchmark.cpp
+++ b/benchmark/run_benchmark.cpp
@@ -1,0 +1,138 @@
+#include <iostream>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <unistd.h>
+#include "benchmark_client.hpp"
+#include "benchmark_dataset.hpp"
+
+#define DEFAULT_BATCH_MIN_SIZE 0
+#define DEFAULT_BATCH_MAX_SIZE 5
+#define DEFAULT_BATCH_TIME_US 500
+#define DEFAULT_DIMENSIONS 1024
+#define DEFAULT_NUM_QUERIES 10
+
+void print_help(const std::string& bin_name){
+    std::cout << "usage: " << bin_name << " [options] <dataset_dir>" << std::endl;
+    std::cout << "options:" << std::endl;
+    std::cout << " -n <num_queries>\ttotal number of queries to send (default: " << DEFAULT_NUM_QUERIES << ")" << std::endl;
+    std::cout << " -e <emb_dim>\t\tembeddings dimensions (default: " << DEFAULT_DIMENSIONS << ")" << std::endl;
+    std::cout << " -r <send_rate>\t\trate (in queries/second) at which to send queries (default: unlimited)" << std::endl;
+    std::cout << " -b <batch_min_size>\tminimum batch size (default: " << DEFAULT_BATCH_MIN_SIZE << ")" << std::endl;
+    std::cout << " -x <batch_max_size>\tmaximum batch size (default: " << DEFAULT_BATCH_MAX_SIZE << ")" << std::endl;
+    std::cout << " -u <batch_time_us>\tmaximum time to wait for the batch minimum size, in microseconds (default: " << DEFAULT_BATCH_TIME_US << ")" << std::endl;
+    std::cout << " -h\t\t\tshow this help" << std::endl;
+}
+
+int main(int argc, char** argv){
+    char c;
+    uint64_t send_rate = 0;
+    bool rate_control = false;
+    uint64_t batch_min_size = DEFAULT_BATCH_MIN_SIZE;
+    uint64_t batch_max_size = DEFAULT_BATCH_MAX_SIZE;
+    uint64_t batch_time_us = DEFAULT_BATCH_TIME_US;
+    uint64_t num_queries = DEFAULT_NUM_QUERIES;
+    uint64_t emb_dim = DEFAULT_DIMENSIONS;
+
+    while ((c = getopt(argc, argv, "n:e:r:b:x:u:h")) != -1){
+        switch(c){
+            case 'n':
+                num_queries = strtoul(optarg,NULL,10);
+                break;
+            case 'e':
+                emb_dim = strtoul(optarg,NULL,10);
+                break;
+            case 'r':
+                send_rate = strtoul(optarg,NULL,10);
+                break;
+            case 'b':
+                batch_min_size = strtoul(optarg,NULL,10);
+                break;
+            case 'x':
+                batch_max_size = strtoul(optarg,NULL,10);
+                break;
+            case 'u':
+                batch_time_us = strtoul(optarg,NULL,10);
+                break;
+            case '?':
+            case 'h':
+            default:
+                print_help(argv[0]);
+                return 0;
+        }
+    }
+
+    if(optind >= argc){
+        print_help(argv[0]);
+        return 0;
+    }
+
+    std::string dataset_dir(argv[optind]);
+    std::chrono::nanoseconds iteration_time;
+    if(send_rate != 0){
+        rate_control = true;
+        iteration_time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds(1)) / send_rate;
+    }
+
+    std::cout << "starting benchmark ..." << std::endl;
+    std::cout << "  num_queries = " << num_queries << std::endl;
+    std::cout << "  send_rate = " << send_rate << std::endl;
+    std::cout << "  emb_dim = " << emb_dim << std::endl;
+    std::cout << "  batch_min_size = " << batch_min_size << std::endl;
+    std::cout << "  batch_max_size = " << batch_max_size << std::endl;
+    std::cout << "  batch_time_us = " << batch_time_us << std::endl;
+    std::cout << "  dataset_dir = " << dataset_dir << std::endl;
+
+    VortexBenchmarkDataset dataset(dataset_dir,num_queries,emb_dim);
+    VortexBenchmarkClient vortex;
+
+    // setup
+    std::cout << "setting up client ..." << std::endl;
+    vortex.setup(batch_min_size,batch_max_size,batch_time_us,emb_dim);
+
+    // send queries
+    std::cout << "sending " << num_queries << " queries ..." << std::endl;
+    std::unordered_map<uint64_t,uint64_t> query_id_to_index;
+    auto extra_time = std::chrono::nanoseconds(0);
+    for(uint64_t i=0;i<num_queries;i++){
+        auto start = std::chrono::steady_clock::now();
+        if (i % 200 == 0){
+            std::cout << "  sent " << i << std::endl;
+        }
+
+        uint64_t next_query_index = dataset.get_next_query_index();
+        const std::string& query_text = dataset.get_query(next_query_index);
+        const float* query_emb = dataset.get_embeddings(next_query_index);
+        uint64_t query_id = vortex.query(query_text,query_emb);
+        query_id_to_index[query_id] = next_query_index;
+        
+        auto end = std::chrono::steady_clock::now();
+        if(rate_control){
+            auto elapsed = end - start + extra_time;
+            auto sleep_time = iteration_time - elapsed;
+            start = std::chrono::steady_clock::now();
+            std::this_thread::sleep_for(sleep_time);
+            extra_time = std::chrono::steady_clock::now() - start - sleep_time;
+        }
+    }
+    std::cout << "  all queries sent!" << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // wait until all results are received
+    std::cout << "waiting all results to arrive ..." << std::endl;
+    vortex.wait_results();
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // TODO recall
+    std::cout << "computing recall ..." << std::endl;
+    // vortex.get_result(query_id); 
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // write timestamps
+    std::cout << "dumping timestamps ..." << std::endl;
+    vortex.dump_timestamps();
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    return 0;
+}
+

--- a/benchmark/setup/object_pools.list
+++ b/benchmark/setup/object_pools.list
@@ -1,3 +1,6 @@
-/rag/emb VCSS 0 cluster[0-9]+
+/rag/emb/centroids_obj VCSS 0 cluster[0-9]+
+/rag/emb/centroids_search VCSS 0 cluster[0-9]+
+/rag/emb/clusters VCSS 1 cluster[0-9]+
+/rag/emb/clusters_search VCSS 1 cluster[0-9]+
+/rag/generate VCSS 2 _qid[0-9a-fA-F]+
 /rag/doc PCSS 0
-/rag/generate VCSS 0 _qid[0-9a-fA-F]+

--- a/benchmark/setup/perf_test_setup.py
+++ b/benchmark/setup/perf_test_setup.py
@@ -139,7 +139,7 @@ def put_initial_embeddings_docs(capi, basepath, put_docs=True, embed_dim=1024):
         num_embeddings = cluster_embs.shape[0]
         cluster_chunk_idx = break_into_chunks(num_embeddings, NUM_EMB_PER_OBJ)
         for i, (start_idx, end_idx) in enumerate(cluster_chunk_idx):
-            key = f"/rag/emb/cluster{cluster_id}/{i}"
+            key = f"/rag/emb/clusters/cluster{cluster_id}/{i}"
             cluster_embs_chunk = cluster_embs[start_idx:end_idx]
             res = capi.put(key, cluster_embs_chunk.tobytes())
             if res:

--- a/cfg/layout.json.tmp
+++ b/cfg/layout.json.tmp
@@ -41,11 +41,11 @@
         "type_alias":   "PersistentCascadeStoreWithStringKey",
         "layout":       [
                             {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "reserved_node_ids_by_shard": [["1"]],
-                                "profiles_by_shard": ["DEFAULT"]
+                                "min_nodes_by_shard": ["1","1"],
+                                "max_nodes_by_shard": ["1","1"],
+                                "delivery_modes_by_shard": ["Ordered","Ordered"],
+                                "reserved_node_ids_by_shard": [["0"],["1"]],
+                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
                             }
                         ]
     },

--- a/cfg/layout.json.tmp
+++ b/cfg/layout.json.tmp
@@ -20,6 +20,20 @@
                                 "delivery_modes_by_shard": ["Ordered","Ordered"],
                                 "reserved_node_ids_by_shard": [["0"],["1"]],
                                 "profiles_by_shard": ["DEFAULT","DEFAULT"]
+                            },
+                            {
+                                "min_nodes_by_shard": ["1","1"],
+                                "max_nodes_by_shard": ["1","1"],
+                                "delivery_modes_by_shard": ["Ordered","Ordered"],
+                                "reserved_node_ids_by_shard": [["0"],["1"]],
+                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
+                            },
+                            {
+                                "min_nodes_by_shard": ["1","1"],
+                                "max_nodes_by_shard": ["1","1"],
+                                "delivery_modes_by_shard": ["Ordered","Ordered"],
+                                "reserved_node_ids_by_shard": [["0"],["1"]],
+                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
                             }
                         ]
     },

--- a/cfg/n0/derecho.cfg
+++ b/cfg/n0/derecho.cfg
@@ -37,7 +37,7 @@ max_p2p_request_payload_size = 1048576
 # maximum payload size for P2P replies
 max_p2p_reply_payload_size = 1048576
 # window size for P2P requests and replies
-p2p_window_size = 4
+p2p_window_size = 8
 
 # Subgroup configurations
 # - The default subgroup settings

--- a/cfg/n1/derecho.cfg
+++ b/cfg/n1/derecho.cfg
@@ -37,7 +37,7 @@ max_p2p_request_payload_size = 1048576
 # maximum payload size for P2P replies
 max_p2p_reply_payload_size = 1048576
 # window size for P2P requests and replies
-p2p_window_size = 4
+p2p_window_size = 8
 
 # Subgroup configurations
 # - The default subgroup settings

--- a/cfg/n2/derecho.cfg
+++ b/cfg/n2/derecho.cfg
@@ -37,7 +37,7 @@ max_p2p_request_payload_size = 1048576
 # maximum payload size for P2P replies
 max_p2p_reply_payload_size = 1048576
 # window size for P2P requests and replies
-p2p_window_size = 4
+p2p_window_size = 8
 
 # Subgroup configurations
 # - The default subgroup settings

--- a/cfg/n3/derecho.cfg
+++ b/cfg/n3/derecho.cfg
@@ -37,7 +37,7 @@ max_p2p_request_payload_size = 1048576
 # maximum payload size for P2P replies
 max_p2p_reply_payload_size = 1048576
 # window size for P2P requests and replies
-p2p_window_size = 4
+p2p_window_size = 8
 
 # Subgroup configurations
 # - The default subgroup settings

--- a/vortex_udls/clusters_search_udl.cpp
+++ b/vortex_udls/clusters_search_udl.cpp
@@ -10,7 +10,7 @@ namespace cascade{
 #define MY_UUID     "11a2c123-2200-21ac-1755-0002ac220000"
 #define MY_DESC     "UDL search within the clusters to find the top K embeddings that the queries close to."
 
-#define CLUSTER_EMB_OBJECTPOOL_PREFIX "/rag/emb/cluster"
+#define CLUSTER_EMB_OBJECTPOOL_PREFIX "/rag/emb/clusters/cluster"
 
 std::string get_uuid() {
     return MY_UUID;


### PR DESCRIPTION
I refactored the client to improve a few things. I kept the code for the old client for now, but I think the new one does everything the old one does and more, so it should be safe to remove the old code.

Here is a summary of the changes in this PR:
- several object pools in different subgroups are created, so we have the control to map each UDL to run on a separate (or same) set of nodes
- the notification handler in the client is as small as possible (it just copies the Blob to a queue), so we avoid blocking UDL3 as much as possible (due to the p2p window size). Note that we should also implement batching/buffering in UDL3, I'll discuss this later.
- the client now has a pool of threads to handle the results received (default 1 thread). Multiple threads may yield some benefit when throughput is high and/or the notification become big (e.g. if we batch them). 
- The client now sends queries from the dataset at a given rate (in queries/second). These queries are batched according to three parameters. Parameter _batch_min_size_ sets the minimum size for a batch, while _batch_max_size_ sets the maximum size. There is a thread that monitors the queue of queries and decides when to send a batch. This thread will wait up to _batch_time_us_ microseconds to gather the minimum batch size. If this time exceeds, the everything available is sent. If the minimum size is 0, the batching is opportunistic, i.e. everything in the queue is sent up to the maximum size.
  - This means that _num_queries_ now is the total number of queries sent, not the number of batches as in the old client.
  - This also means that the new client can be used both for latency and throughput evaluations.
- The client now has an option _-d_ that makes it not dump the timestamps at the end of the execution. This is important so we can run multiple clients in parallel and have just one of them do the dump.
- The client shows some batching statistic at the end of execution (e.g. average batch size). Note that if using opportunistic batching, batches will only be bigger than 1 if the sending rate is fast enough.

The new client is the executable 'run_benchmark':
```
usage: ../../run_benchmark [options] <dataset_dir>
options:
 -n <num_queries>           total number of queries to send (default: 10)
 -e <emb_dim>               embeddings dimensions (default: 1024)
 -r <send_rate>             rate (in queries/second) at which to send queries (default: unlimited)
 -b <batch_min_size>        minimum batch size (default: 0)
 -x <batch_max_size>        maximum batch size (default: 5)
 -u <batch_time_us>         maximum time to wait for the batch minimum size, in microseconds (default: 500)
 -t <num_result_threads>    number of threads for processing results (default: 1)
 -d                         do not dump timestamps in the remote servers (default: true)
 -h                         show this help
```

Example:
```
$ ../../run_benchmark -n 100 -r 10 -x 10 -e 960 -t 1 ~/devel/datasets/gist/
starting benchmark ...
  num_queries = 100
  send_rate = 10
  emb_dim = 960
  batch_min_size = 0
  batch_max_size = 10
  batch_time_us = 500
  num_result_threads = 1
  dump = 1
  dataset_dir = /home/tgarr/distrobox/cascade-ubuntu/devel/datasets/gist/
setting up client ...
  creating object pool for receiving results: /rag/results/2
  registering notification handler ... /rag/results/2
  pre-establishing connections with all nodes in 2 shards ...
sending 100 queries ...
  sent 0
  all queries sent!
waiting all results to arrive ...
  received 100
computing recall ...
 avg recall: 0.954
dumping timestamps ...
batching statistics:
  avg: 1
  median: 1
  min: 1
  max: 1
  p95: 1
```
