### PR TITLE
fix for blob object corruption due to move instead of copying in cascade queue

### DIFF
--- a/vortex_udls/centroids_search_udl.cpp
+++ b/vortex_udls/centroids_search_udl.cpp
@@ -162,7 +162,7 @@ void CentroidsSearchOCDPO::ProcessBatchedTasksThread::process_task(std::unique_p
     if (parent->include_encoder && data) 
         delete[] data;
     // after using the batched task's blob data, release the memory
-    task_ptr->blob.memory_mode = derecho::cascade::object_memory_mode_t::DEFAULT;
+    // task_ptr->blob.memory_mode = derecho::cascade::object_memory_mode_t::DEFAULT;
     TimestampLogger::log(LOG_CENTROIDS_EMBEDDINGS_UDL_END,task_ptr->client_id,task_ptr->query_batch_id,parent->my_id);
     dbg_default_trace("[Centroids search ocdpo]: FINISHED knn search for key: {}", task_ptr->key);
 }
@@ -229,13 +229,13 @@ void CentroidsSearchOCDPO::ocdpo_handler(const node_id_t sender,
         dbg_default_error("Failed to parse client_id and query_batch_id from key: {}, unable to track correctly.", key_string);
     TimestampLogger::log(LOG_CENTROIDS_EMBEDDINGS_UDL_START,client_id,query_batch_id,this->my_id);
 
-    Blob blob = std::move(const_cast<Blob&>(object.blob));
-    blob.memory_mode = derecho::cascade::object_memory_mode_t::EMPLACED;
+    // Blob blob = std::move(const_cast<Blob&>(object.blob));
+    // blob.memory_mode = derecho::cascade::object_memory_mode_t::EMPLACED;
     // Append the batched queries task to the queue
     new_request = true;
     std::unique_lock<std::mutex> lock(active_tasks_mutex); 
 
-    active_tasks_queue.push(std::make_unique<batchedTask>(key_string, client_id, query_batch_id, std::move(blob)));
+    active_tasks_queue.push(std::make_unique<batchedTask>(key_string, client_id, query_batch_id, object.blob));
     new_request = false;
     lock.unlock();
     active_tasks_cv.notify_one();

--- a/vortex_udls/centroids_search_udl.hpp
+++ b/vortex_udls/centroids_search_udl.hpp
@@ -31,8 +31,8 @@ struct batchedTask {
     // std::vector<std::string> queries;
     // // CURL *curl;
     // std::unique_ptr<float[]> all_embeddings;
-    batchedTask(std::string key, uint32_t client_id, uint32_t query_batch_id, Blob&& blob)
-        : key(key), client_id(client_id), query_batch_id(query_batch_id), blob(std::move(blob)) {}
+    batchedTask(std::string key, uint32_t client_id, uint32_t query_batch_id, Blob blob)
+        : key(key), client_id(client_id), query_batch_id(query_batch_id), blob(blob) {}
 };
 
 class CentroidsSearchOCDPO: public DefaultOffCriticalDataPathObserver {


### PR DESCRIPTION
Implementation at UDL1 centroids search, which keeps a local queue based on directly move the object from the cascade queued blob objects. This introduce a problem when load is large and the processing of those objects on the queue not catching up with the queued objects, because the local queued objects could be corrupted if that memory has been used due to high volumn of arriving p2p messages.  Then at the processing thread, when it deserialize the blob objects from the queue, it will read a corrupted blob objects and could return errors like: "Segmentation fault" or "Error: failed to deserialize the query embeddings and query texts from the object."
Change this to do a copy instead of move to the local queue.
For UDL2 cluster search, i used the copy of the object instead of move the blob, so UDL2 is free from this type of issue.