### PR TITLE
Code refactored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(centroids_search_udl SHARED
                             vortex_udls/centroids_search_udl.hpp 
                             vortex_udls/centroids_search_udl.cpp 
                             vortex_udls/serialize_utils.cpp 
+                            vortex_udls/grouped_embeddings_for_search.cpp
                             vortex_udls/api_utils.cpp)
 target_link_libraries(centroids_search_udl PRIVATE ${UDL_COMMON_LIBS} CURL::libcurl)
 target_compile_definitions(centroids_search_udl PRIVATE
@@ -128,6 +129,7 @@ target_compile_definitions(centroids_search_udl PRIVATE
 add_library(clusters_search_udl SHARED 
                                 vortex_udls/clusters_search_udl.hpp 
                                 vortex_udls/clusters_search_udl.cpp 
+                                vortex_udls/grouped_embeddings_for_search.cpp
                                 vortex_udls/serialize_utils.cpp)
 target_link_libraries(clusters_search_udl PRIVATE ${UDL_COMMON_LIBS})
 

--- a/vortex_udls/aggregate_generate_udl.cpp
+++ b/vortex_udls/aggregate_generate_udl.cpp
@@ -203,7 +203,7 @@ void AggGenOCDPO::ProcessThread::main_loop(DefaultCascadeContextType* typed_ctxt
         auto pending_count = this->pending_tasks.size();
         auto current_batch_count = 0;
         // move out the pending tasks in batch to be processed
-        if (pending_count > parent->min_batch_size || (now - wait_start) < batch_time) {
+        if (pending_count >= parent->min_batch_size || (now - wait_start) >= batch_time) {
             current_batch_count = std::min(pending_count, static_cast<size_t>(parent->max_batch_size));
             wait_start = now;
             while (!this->pending_tasks.empty() && tasks.size() < current_batch_count) {

--- a/vortex_udls/centroids_search_udl.cpp
+++ b/vortex_udls/centroids_search_udl.cpp
@@ -151,6 +151,9 @@ void CentroidsSearchOCDPO::ProcessBatchedTasksThread::main_loop(DefaultCascadeCo
         });
         if (!running)
             break;
+        if (parent->active_tasks_queue.empty()) {
+            continue;
+        }
         std::unique_ptr<batchedTask> task = std::move(parent->active_tasks_queue.front());
         parent->active_tasks_queue.pop();
         lock.unlock();

--- a/vortex_udls/centroids_search_udl.hpp
+++ b/vortex_udls/centroids_search_udl.hpp
@@ -38,8 +38,7 @@ struct batchedTask {
 class CentroidsSearchOCDPO: public DefaultOffCriticalDataPathObserver {
 
     /***
-     * A thread class to wait for the encoder result of the queries
-     * then compute topk centroids and emit to the next UDL
+     * A thread class to compute topk centroids and emit to the next UDL
      */
     class ProcessBatchedTasksThread {
         private:
@@ -82,9 +81,6 @@ class CentroidsSearchOCDPO: public DefaultOffCriticalDataPathObserver {
     int emb_dim = 64; // dimension of each embedding
     int top_num_centroids = 4; // number of top K embeddings to search
     int faiss_search_type = 0; // 0: CPU flat search, 1: GPU flat search, 2: GPU IVF search
-    bool include_encoder = false; // if the external client's query already contain embeddings, then no need to generate them here
-    std::string encoder_name = "text-embedding-3-small";
-    std::string openai_api_key;
     std::string emit_key_prefix = "/rag/emb/clusters_search";
     
     std::atomic<bool> new_request = false;

--- a/vortex_udls/clusters_search_udl.cpp
+++ b/vortex_udls/clusters_search_udl.cpp
@@ -260,9 +260,9 @@ void ClustersSearchOCDPO::ocdpo_handler(const node_id_t sender,
         dbg_default_error("Failed to parse client_id and query_batch_id from key: {}, unable to track correctly.", key_string);
     TimestampLogger::log(LOG_CLUSTER_SEARCH_UDL_START,client_id,query_batch_id,parsed_cluster_id);
     // 1. Move the object to the active queue to be processed
-    uint64_t to_thread = query_batch_id % this->num_threads;
-    this->cluster_search_threads[to_thread]->push_to_query_buffer(parsed_cluster_id, object.blob, key_string);
-    dbg_default_trace("[Cluster search ocdpo]: PUT {} to active queue on thread{}.", key_string, to_thread);
+    this->cluster_search_threads[next_thread]->push_to_query_buffer(parsed_cluster_id, object.blob, key_string);
+    dbg_default_trace("[Cluster search ocdpo]: PUT {} to active queue on thread{}.", key_string, next_thread);
+    next_thread = (next_thread + 1) % this->num_threads; // cycle
 }
 
 

--- a/vortex_udls/clusters_search_udl.hpp
+++ b/vortex_udls/clusters_search_udl.hpp
@@ -51,7 +51,7 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
 
         std::unique_ptr<queryQueue> query_buffer;
         std::unique_ptr<queryQueue> shadow_query_buffer;
-        std::atomic<int> use_shadow_flag;  // if this is 1, then add to shadow_query_buffer, otherwise add to query_buffer
+        int use_shadow_flag;  // if this is 1, then add to shadow_query_buffer, otherwise add to query_buffer
         std::condition_variable_any query_buffer_cv;
         std::mutex query_buffer_mutex;
         

--- a/vortex_udls/clusters_search_udl.hpp
+++ b/vortex_udls/clusters_search_udl.hpp
@@ -23,8 +23,6 @@ namespace cascade{
 #define CLUSTER_EMB_OBJECTPOOL_PREFIX "/rag/emb/clusters/cluster"
 #define EMIT_AGGREGATE_PREFIX "/rag/generate/agg"
 
-constexpr size_t CACHE_LINE_SIZE = 64;
-constexpr size_t INITIAL_QUEUE_CAPACITY = 1024;
 
 std::string get_uuid() {
     return MY_UUID;
@@ -34,22 +32,7 @@ std::string get_description() {
     return MY_DESC;
 }
 
-struct queryQueue{
-    std::vector<std::string> query_list;
-    std::vector<std::string> query_keys;
-    float* query_embs;
-    size_t query_embs_capacity; 
-    std::atomic<size_t> added_query_offset;
-    int emb_dim;
 
-    queryQueue(int emb_dim);
-    ~queryQueue();
-    float* aligned_alloc(size_t size);
-    void resize_queue(size_t new_capacity);
-    bool add_queries(std::vector<std::string>&& queries, const std::string& key, float* embs, int emb_dim, int num_queries);
-    int count_queries();
-    void reset();
-};
 
 
 class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {

--- a/vortex_udls/clusters_search_udl.hpp
+++ b/vortex_udls/clusters_search_udl.hpp
@@ -110,6 +110,7 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
     size_t min_batch_size = 1; // min number queries to process in each batch
     size_t max_batch_size = 1000; // max number queries to process in each batch, for hnsw search, set it to 1 is optimal
     int num_threads = 1; // number of threads to process the cluster search
+    uint64_t next_thread = 0;
 
     int cluster_id = -1; // the cluster that this node handles
     mutable std::shared_mutex cluster_search_index_mutex;

--- a/vortex_udls/clusters_search_udl.hpp
+++ b/vortex_udls/clusters_search_udl.hpp
@@ -13,8 +13,6 @@
 #include "grouped_embeddings_for_search.hpp"
 #include "api_utils.hpp"
 
-#define EMIT_AGGREGATE_PREFIX "/rag/generate/agg"
-
 
 namespace derecho{
 namespace cascade{
@@ -23,6 +21,10 @@ namespace cascade{
 #define MY_DESC     "UDL search within the clusters to find the top K embeddings that the queries close to."
 
 #define CLUSTER_EMB_OBJECTPOOL_PREFIX "/rag/emb/clusters/cluster"
+#define EMIT_AGGREGATE_PREFIX "/rag/generate/agg"
+
+constexpr size_t CACHE_LINE_SIZE = 64;
+constexpr size_t INITIAL_QUEUE_CAPACITY = 1024;
 
 std::string get_uuid() {
     return MY_UUID;
@@ -36,14 +38,15 @@ struct queryQueue{
     std::vector<std::string> query_list;
     std::vector<std::string> query_keys;
     float* query_embs;
-    std::atomic<int> added_query_offset;
+    size_t query_embs_capacity; 
+    std::atomic<size_t> added_query_offset;
     int emb_dim;
 
     queryQueue(int emb_dim);
     ~queryQueue();
-    bool add_query(std::string&& query, std::string&& key, float* emb, int emb_dim);
-    bool add_batched_queries(std::vector<std::string>&& queries, const std::string& key, float* embs, int emb_dim, int num_queries);
-    bool could_add_query_nums(uint32_t num_queries);
+    float* aligned_alloc(size_t size);
+    void resize_queue(size_t new_capacity);
+    bool add_queries(std::vector<std::string>&& queries, const std::string& key, float* embs, int emb_dim, int num_queries);
     int count_queries();
     void reset();
 };
@@ -62,7 +65,6 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
 
         bool running = false;
         std::thread real_thread;
-        int cluster_id = -1; // the cluster that this worker handles
 
         std::unique_ptr<queryQueue> query_buffer;
         std::unique_ptr<queryQueue> shadow_query_buffer;
@@ -71,8 +73,6 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
         std::mutex query_buffer_mutex;
         
 
-
-        bool check_and_retrieve_cluster_index(DefaultCascadeContextType* typed_ctxt);
         /***
         * Format the new_keys for the search results of the queries
         * it is formated as client{client_id}qb{querybatch_id}qc{client_batch_query_count}_cluster{cluster_id}_qid{hash(query)}
@@ -81,20 +81,23 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
         * @param query_list a list of query strings
         ***/
         void construct_new_keys(std::vector<std::string>& new_keys,
-                                                       const std::vector<std::string>& query_keys, 
-                                                       const std::vector<std::string>& query_list);
+                                std::vector<std::string>::const_iterator keys_begin,
+                                std::vector<std::string>::const_iterator keys_end,
+                                std::vector<std::string>::const_iterator queries_begin,
+                                std::vector<std::string>::const_iterator queries_end);
+
+        // Helper function: Emit results to the next UDL
+        void emit_results(DefaultCascadeContextType* typed_ctxt,
+                        const std::vector<std::string>& new_keys,
+                        const std::vector<std::string>& query_list,
+                        long* I, float* D, size_t start_idx, size_t batch_size);
         /***
          * Run ANN algorithm on batch of queries from query_buffer and emit the results once the whole batch finishes
          *  used for batchable search, which is more performant when the number of queries is large
         */
-        void run_batched_cluster_search_and_emit(DefaultCascadeContextType* typed_ctxt,
+        void run_cluster_search_and_emit(DefaultCascadeContextType* typed_ctxt,
                                         queryQueue* query_buffer);
-        /***
-         * Run ANN algorithm on the queries from query_buffer and emit the result one-by-one
-         *  used when hnsw search is enabled, which is not batchable
-         */
-        void run_cluster_search_and_emit_per_query(DefaultCascadeContextType* typed_ctxt,
-                                        queryQueue* query_buffer);
+        
         /*** Helper function to check if there are enough pending queries on
          *   the buffer that have been added by the push_thread
          *   If so, then flip the flag to have the push_thread to start a new buffer, 
@@ -121,15 +124,18 @@ class ClustersSearchOCDPO: public DefaultOffCriticalDataPathObserver {
     int faiss_search_type = 0; // 0: CPU flat search, 1: GPU flat search, 2: GPU IVF search
     int my_id; // the node id of this node; logging purpose
     uint32_t batch_time_us = 1000; // the time interval to process the batch of queries
-    uint32_t batch_min_size = 1; // min number queries to process in each batch
+    size_t min_batch_size = 1; // min number queries to process in each batch
+    size_t max_batch_size = 1000; // max number queries to process in each batch, for hnsw search, set it to 1 is optimal
     int num_threads = 1; // number of threads to process the cluster search
 
+    int cluster_id = -1; // the cluster that this node handles
     mutable std::shared_mutex cluster_search_index_mutex;
     mutable std::condition_variable_any cluster_search_index_cv;
     // maps from cluster ID -> embeddings of that cluster, 
     // use pointer to allow multithreading adding queries to different GroupedEmbeddingsForSearch objects
     std::shared_ptr<GroupedEmbeddingsForSearch> cluster_search_index;    
 
+    bool check_and_retrieve_cluster_index(DefaultCascadeContextType* typed_ctxt);
     virtual void ocdpo_handler(const node_id_t sender,
                                const std::string& object_pool_pathname,
                                const std::string& key_string,

--- a/vortex_udls/grouped_embeddings_for_search.cpp
+++ b/vortex_udls/grouped_embeddings_for_search.cpp
@@ -1,0 +1,318 @@
+
+
+#include "grouped_embeddings_for_search.hpp"
+
+namespace derecho{
+namespace cascade{
+
+
+queryQueue::queryQueue(int emb_dim): emb_dim(emb_dim) {
+    query_list.reserve(INITIAL_QUEUE_CAPACITY);
+    query_keys.reserve(INITIAL_QUEUE_CAPACITY);
+    query_embs_capacity = INITIAL_QUEUE_CAPACITY;
+    query_embs = aligned_alloc(query_embs_capacity * emb_dim * sizeof(float));
+    added_query_offset = 0;
+}
+
+queryQueue::~queryQueue() {
+    delete[] query_embs;
+}
+
+float* queryQueue::aligned_alloc(size_t size) {
+    void* ptr = nullptr;
+    if (posix_memalign(&ptr, CACHE_LINE_SIZE, size) != 0) {
+        throw std::bad_alloc();
+    }
+    return static_cast<float*>(ptr);
+}
+
+void queryQueue::resize_queue(size_t new_query_capacity) {
+    size_t new_capacity_in_elements = new_query_capacity * emb_dim;
+    float* new_embs = aligned_alloc(new_capacity_in_elements * sizeof(float));
+    size_t current_size_in_elements = added_query_offset.load();
+    memcpy(new_embs, query_embs, current_size_in_elements * sizeof(float));
+    free(query_embs); // Free the old memory
+    query_embs = new_embs;
+    query_embs_capacity = new_query_capacity;
+    query_list.reserve(new_query_capacity);
+    query_keys.reserve(new_query_capacity);
+}
+
+bool queryQueue::add_queries(std::vector<std::string>&& queries, const std::string& key, float* embs, int emb_dim, int num_queries) {
+    if (this->emb_dim != emb_dim) {
+        return false;
+    }
+    size_t required_queries = added_query_offset / this->emb_dim + num_queries;
+    if (required_queries > query_embs_capacity) {
+        size_t new_query_capacity = query_embs_capacity;
+        while (required_queries > new_query_capacity) {
+            new_query_capacity *= 2;
+        }
+        resize_queue(new_query_capacity);
+    }
+    query_list.insert(query_list.end(), std::make_move_iterator(queries.begin()), std::make_move_iterator(queries.end()));
+    query_keys.insert(query_keys.end(), num_queries, key);
+    // TODO: could do better by only one copy from the blob object at deserialization
+    memcpy(query_embs + added_query_offset, embs, num_queries * emb_dim * sizeof(float));
+    added_query_offset += num_queries * emb_dim;
+    return true;
+}
+
+int queryQueue::count_queries() {
+    return query_list.size();
+}
+
+void queryQueue::reset() {
+    query_list.clear();
+    query_keys.clear();
+    added_query_offset = 0;
+}
+
+
+float* GroupedEmbeddingsForSearch::single_emb_object_retrieve(int& retrieved_num_embs,
+                                        std::string& cluster_emb_key,
+                                        DefaultCascadeContextType* typed_ctxt,
+                                        persistent::version_t version,
+                                        bool stable){
+     float* data;
+     // 1. get the object from KV store
+     auto get_query_results = typed_ctxt->get_service_client_ref().get(cluster_emb_key,version, stable);
+     auto& reply = get_query_results.get().begin()->second.get();
+     Blob blob = std::move(const_cast<Blob&>(reply.blob));
+     blob.memory_mode = derecho::cascade::object_memory_mode_t::EMPLACED; // Avoid copy, use bytes from reply.blob, transfer its ownership to GroupedEmbeddingsForSearch.emb_data
+     // 2. get the embeddings from the object
+     data = const_cast<float*>(reinterpret_cast<const float *>(blob.bytes));
+     size_t num_points = blob.size / sizeof(float);
+     retrieved_num_embs += num_points / this->emb_dim;
+     return data;
+}
+
+
+float* GroupedEmbeddingsForSearch::multi_emb_object_retrieve(int& retrieved_num_embs,
+                                   std::priority_queue<std::string, std::vector<std::string>, CompareObjKey>& emb_obj_keys,
+                                   DefaultCascadeContextType* typed_ctxt,
+                                   persistent::version_t version,
+                                   bool stable){
+     float* data;
+     size_t num_obj = emb_obj_keys.size();
+     size_t data_size = 0;
+     Blob blobs[num_obj];
+     size_t i = 0;
+     while (!emb_obj_keys.empty()){
+          std::string emb_obj_key = emb_obj_keys.top();
+          emb_obj_keys.pop();
+          auto get_query_results = typed_ctxt->get_service_client_ref().get(emb_obj_key,version, stable);
+          auto& reply = get_query_results.get().begin()->second.get();
+          blobs[i] = std::move(const_cast<Blob&>(reply.blob));
+          data_size += blobs[i].size / sizeof(float);  
+          i++;
+     }
+     // 2. copy the embeddings from the blobs to the data
+     data = (float*)malloc(data_size * sizeof(float));
+     size_t offset = 0;
+     for (size_t i = 0; i < num_obj; i++) {
+          memcpy(data + offset, blobs[i].bytes, blobs[i].size);
+          offset += blobs[i].size / sizeof(float);
+     }
+     retrieved_num_embs = data_size / this->emb_dim;
+     return data;
+}
+
+int GroupedEmbeddingsForSearch::retrieve_grouped_embeddings(std::string embs_prefix,
+                                   DefaultCascadeContextType* typed_ctxt){
+     bool stable = 1; 
+     persistent::version_t version = CURRENT_VERSION;
+     // 0. check the keys for this grouped embedding objects stored in cascade
+     //    because of the message size, one cluster might need multiple objects to store its embeddings
+     auto keys_future = typed_ctxt->get_service_client_ref().list_keys(version, stable, embs_prefix);
+     std::vector<std::string> listed_emb_obj_keys = typed_ctxt->get_service_client_ref().wait_list_keys(keys_future);
+     if (listed_emb_obj_keys.empty()) {
+          std::cerr << "Error: prefix [" << embs_prefix <<"] has no embedding object found in the KV store" << std::endl;
+          dbg_default_error("[{}]at {}, Failed to find object prefix {} in the KV store.", gettid(), __func__, embs_prefix);
+          return -1;
+     }
+     std::priority_queue<std::string, std::vector<std::string>, CompareObjKey> emb_obj_keys = filter_exact_matched_keys(listed_emb_obj_keys, embs_prefix);
+
+     // 1. Get the cluster embeddings from KV store in Cascade
+     float* data;
+     int num_retrieved_embs = 0;
+     if (emb_obj_keys.size() == 1) {
+          std::string emb_obj_key = emb_obj_keys.top();
+          data = single_emb_object_retrieve(num_retrieved_embs, emb_obj_key, typed_ctxt, version, stable);
+     } else {
+          data = multi_emb_object_retrieve(num_retrieved_embs, emb_obj_keys, typed_ctxt, version ,stable);
+     }
+     if (num_retrieved_embs == 0) {
+          std::cerr << "Error: embs_prefix:" << embs_prefix <<" has no embeddings found in the KV store" << std::endl;
+          dbg_default_error("[{}]at {}, There is no embeddings for prefix{} in the KV store.", gettid(), __func__, embs_prefix);
+          return -1;
+     }
+     dbg_default_trace("[{}]: embs_prefix={}, num_emb_objects={} retrieved.", __func__, embs_prefix, num_retrieved_embs);
+
+     // 2. assign the retrieved embeddings
+     this->num_embs = num_retrieved_embs;
+     this->embeddings = data;
+     // this->centroids_embs[cluster_id]= std::make_unique<GroupedEmbeddingsForSearch>(this->emb_dim, retrieved_num_embs, data);
+     // int init_search_res = this->initialize_groupped_embeddings_for_search();
+     return 0;
+}
+
+int GroupedEmbeddingsForSearch::get_num_embeddings(){
+     return this->num_embs;
+}   
+
+int GroupedEmbeddingsForSearch::initialize_groupped_embeddings_for_search(){
+     switch (this->search_type) {
+     case SearchType::FaissCpuFlatSearch:
+          initialize_cpu_flat_search();
+          break;
+     case SearchType::FaissGpuFlatSearch:
+          initialize_gpu_flat_search();
+          break;
+     case SearchType::FaissGpuIvfSearch:
+          initialize_gpu_ivf_flat_search();
+          break;
+     case SearchType::HnswlibCpuSearch:
+          initialize_cpu_hnsw_search();
+          break;
+     default:
+          std::cerr << "Error: faiss_search_type not supported" << std::endl;
+          dbg_default_error("Failed to initialize faiss search type, at clusters_search_udl.");
+          return -1;
+     }
+     initialized_index.store(true);
+     return 0;
+}
+
+void GroupedEmbeddingsForSearch::search(int nq, float* xq, int top_k, float* D, long* I){
+     switch (this->search_type) {
+     case SearchType::FaissCpuFlatSearch:
+          faiss_cpu_flat_search(nq, xq, top_k, D, I);
+          break;
+     case SearchType::FaissGpuFlatSearch:
+          faiss_gpu_flat_search(nq, xq, top_k, D, I);
+          break;
+     case SearchType::FaissGpuIvfSearch:
+          faiss_gpu_ivf_flat_search(nq, xq, top_k, D, I);
+          break;
+     case SearchType::HnswlibCpuSearch:
+          hnsw_cpu_search(nq, xq, top_k, D, I);
+          break;
+     default:
+          std::cerr << "Error: faiss_search_type not supported" << std::endl;
+          dbg_default_error("Failed to search the top K embeddings, at clusters_search_udl.");
+          break;
+     }
+}
+
+void GroupedEmbeddingsForSearch::initialize_cpu_hnsw_search() {
+     this->l2_space = std::make_unique<hnswlib::L2Space>(this->emb_dim);
+     this->cpu_hnsw_index = std::make_unique<hnswlib::HierarchicalNSW<float>>(l2_space.get(), this->num_embs, M, EF_CONSTRUCTION);
+
+     for(size_t i = 0; i < this->num_embs; i++) {
+          this->cpu_hnsw_index->addPoint(this->embeddings + (i * this->emb_dim), i);
+     }
+}
+
+int GroupedEmbeddingsForSearch::hnsw_cpu_search(int nq, float* xq, int top_k, float* D, long* I)  {
+     for(size_t i = 0; i < nq; i++) {
+          const float* query_vector = xq + (i * this->emb_dim);
+
+          auto results = std::move(this->cpu_hnsw_index->searchKnn(query_vector, top_k));
+
+          for(size_t k = 0; k < top_k; k++) {
+               auto [distance, idx] = results.top();
+               results.pop();
+
+               // populate distance vector which is (n, k)
+               *(D + (i * top_k) + k) = distance;
+
+               // populate index vector which is  also (n, k)
+               *(I + (i * top_k) + k) = idx;
+          }
+     }
+
+     return 0;
+}
+
+void GroupedEmbeddingsForSearch::initialize_cpu_flat_search(){
+     this->cpu_flatl2_index = std::make_unique<faiss::IndexFlatL2>(this->emb_dim); 
+     this->cpu_flatl2_index->add(this->num_embs, this->embeddings); // add vectors to the index
+}
+
+
+int GroupedEmbeddingsForSearch::faiss_cpu_flat_search(int nq, float* xq, int top_k, float* D, long* I){
+     dbg_default_trace("FAISS CPU flat Search in [GroupedEmbeddingsForSearch] class");
+     this->cpu_flatl2_index->search(nq, xq, top_k, D, I);
+     return 0;
+}
+
+void GroupedEmbeddingsForSearch::initialize_gpu_flat_search(){
+     this->gpu_res = std::make_unique<faiss::gpu::StandardGpuResources>();
+     this->gpu_flatl2_index = std::make_unique<faiss::gpu::GpuIndexFlatL2>(this->gpu_res.get(), this->emb_dim);
+     this->gpu_flatl2_index->add(this->num_embs, this->embeddings); // add vectors to the index
+}
+
+
+int GroupedEmbeddingsForSearch::faiss_gpu_flat_search(int nq, float* xq, int top_k, float* D, long* I){
+     dbg_default_trace("FAISS GPU flatl2 Search in [GroupedEmbeddingsForSearch] class" );
+     this->gpu_flatl2_index->search(nq, xq, top_k, D, I);
+     return 0;
+}
+
+void GroupedEmbeddingsForSearch::initialize_gpu_ivf_flat_search(){
+     int nlist = 100;
+     this->gpu_res = std::make_unique<faiss::gpu::StandardGpuResources>();
+     this->gpu_ivf_flatl2_index = std::make_unique<faiss::gpu::GpuIndexIVFFlat>(this->gpu_res.get(), this->emb_dim, nlist, faiss::METRIC_L2);
+     this->gpu_ivf_flatl2_index->train(this->num_embs, this->embeddings); // train on the embeddings
+     this->gpu_ivf_flatl2_index->add(this->num_embs, this->embeddings); // add vectors to the index
+}
+
+
+int GroupedEmbeddingsForSearch::faiss_gpu_ivf_flat_search(int nq, float* xq, int top_k, float* D, long* I){
+     dbg_default_trace("FAISS GPU ivf Search in [GroupedEmbeddingsForSearch] class" );
+     this->gpu_ivf_flatl2_index->search(nq, xq, top_k, D, I);
+     return 0;
+}
+
+
+void GroupedEmbeddingsForSearch::reset(){
+     if (this->embeddings != nullptr) {
+          free(this->embeddings);
+          this->embeddings = nullptr; 
+     }
+     // index cleanup 
+     if (this->search_type == SearchType::FaissCpuFlatSearch && this->cpu_flatl2_index != nullptr) {
+          this->cpu_flatl2_index->reset();
+     } 
+     else if (this->search_type == SearchType::FaissGpuFlatSearch && this->gpu_flatl2_index != nullptr) {
+          cudaError_t sync_err = cudaDeviceSynchronize();
+          if (sync_err == cudaSuccess) {
+               this->gpu_flatl2_index->reset();  
+               this->gpu_res.reset();
+               this->gpu_flatl2_index=nullptr;
+               this->gpu_res=nullptr;
+               cudaDeviceReset();  
+          } else {
+               std::cerr << "Error during cudaDeviceSynchronize: " << cudaGetErrorString(sync_err) << std::endl;
+          }
+     } 
+     else if (this->search_type == SearchType::FaissGpuIvfSearch && this->gpu_ivf_flatl2_index != nullptr) {
+          cudaError_t sync_err = cudaDeviceSynchronize();
+          if (sync_err == cudaSuccess) {
+               this->gpu_ivf_flatl2_index->reset();  
+               this->gpu_res.reset();
+               this->gpu_ivf_flatl2_index=nullptr;
+               this->gpu_res=nullptr;
+               cudaDeviceReset();  
+          } else {
+               std::cerr << "Error during cudaDeviceSynchronize: " << cudaGetErrorString(sync_err) << std::endl;
+          }
+     } else if (this->search_type == SearchType::HnswlibCpuSearch && this -> cpu_flatl2_index != nullptr) {
+          this->cpu_hnsw_index.reset();
+     }
+}
+
+
+} // namespace cascade
+} // namespace derecho

--- a/vortex_udls/grouped_embeddings_for_search.hpp
+++ b/vortex_udls/grouped_embeddings_for_search.hpp
@@ -26,8 +26,34 @@
 namespace derecho{
 namespace cascade{
 
+constexpr size_t CACHE_LINE_SIZE = 64;
+constexpr size_t INITIAL_QUEUE_CAPACITY = 1024;
+
+/*** Class to buffer the receiving queries
+ */
+struct queryQueue{
+    std::vector<std::string> query_list;
+    std::vector<std::string> query_keys;
+    float* query_embs;
+    size_t query_embs_capacity; 
+    std::atomic<size_t> added_query_offset;
+    int emb_dim;
+
+    queryQueue(int emb_dim);
+    ~queryQueue();
+    float* aligned_alloc(size_t size);
+    void resize_queue(size_t new_capacity);
+    bool add_queries(std::vector<std::string>&& queries, const std::string& key, float* embs, int emb_dim, int num_queries);
+    int count_queries();
+    void reset();
+};
+
+
+/*** Wrapper for the ANN search engine
+ * Store group of embeddings for a cluster or for centroids;
+ * Build the index for the embeddings
+ */
 class GroupedEmbeddingsForSearch{
-// Class to store group of embeddings, which could be the embeddings of a cluster or embeddings of all centroids
 public:
      enum class SearchType {
           FaissCpuFlatSearch = 0,
@@ -82,19 +108,7 @@ public:
                                              std::string& cluster_emb_key,
                                              DefaultCascadeContextType* typed_ctxt,
                                              persistent::version_t version,
-                                             bool stable = 1){
-          float* data;
-          // 1. get the object from KV store
-          auto get_query_results = typed_ctxt->get_service_client_ref().get(cluster_emb_key,version, stable);
-          auto& reply = get_query_results.get().begin()->second.get();
-          Blob blob = std::move(const_cast<Blob&>(reply.blob));
-          blob.memory_mode = derecho::cascade::object_memory_mode_t::EMPLACED; // Avoid copy, use bytes from reply.blob, transfer its ownership to GroupedEmbeddingsForSearch.emb_data
-          // 2. get the embeddings from the object
-          data = const_cast<float*>(reinterpret_cast<const float *>(blob.bytes));
-          size_t num_points = blob.size / sizeof(float);
-          retrieved_num_embs += num_points / this->emb_dim;
-          return data;
-     }
+                                             bool stable = 1);
 
      /*** 
      * Helper function to fill_cluster_embs_in_cache()
@@ -105,31 +119,7 @@ public:
                                         std::priority_queue<std::string, std::vector<std::string>, CompareObjKey>& emb_obj_keys,
                                         DefaultCascadeContextType* typed_ctxt,
                                         persistent::version_t version,
-                                        bool stable = 1){
-          float* data;
-          size_t num_obj = emb_obj_keys.size();
-          size_t data_size = 0;
-          Blob blobs[num_obj];
-          size_t i = 0;
-          while (!emb_obj_keys.empty()){
-               std::string emb_obj_key = emb_obj_keys.top();
-               emb_obj_keys.pop();
-               auto get_query_results = typed_ctxt->get_service_client_ref().get(emb_obj_key,version, stable);
-               auto& reply = get_query_results.get().begin()->second.get();
-               blobs[i] = std::move(const_cast<Blob&>(reply.blob));
-               data_size += blobs[i].size / sizeof(float);  
-               i++;
-          }
-          // 2. copy the embeddings from the blobs to the data
-          data = (float*)malloc(data_size * sizeof(float));
-          size_t offset = 0;
-          for (size_t i = 0; i < num_obj; i++) {
-               memcpy(data + offset, blobs[i].bytes, blobs[i].size);
-               offset += blobs[i].size / sizeof(float);
-          }
-          retrieved_num_embs = data_size / this->emb_dim;
-          return data;
-     }
+                                        bool stable = 1);
 
      /***
      * Fill in the embeddings of that cluster by getting the clusters' embeddings from KV store in Cascade
@@ -145,70 +135,11 @@ public:
      * @note we load the stabled version of the cluster embeddings
      ***/
      int retrieve_grouped_embeddings(std::string embs_prefix,
-                                        DefaultCascadeContextType* typed_ctxt){
-          bool stable = 1; 
-          persistent::version_t version = CURRENT_VERSION;
-          // 0. check the keys for this grouped embedding objects stored in cascade
-          //    because of the message size, one cluster might need multiple objects to store its embeddings
-          auto keys_future = typed_ctxt->get_service_client_ref().list_keys(version, stable, embs_prefix);
-          std::vector<std::string> listed_emb_obj_keys = typed_ctxt->get_service_client_ref().wait_list_keys(keys_future);
-          if (listed_emb_obj_keys.empty()) {
-               std::cerr << "Error: prefix [" << embs_prefix <<"] has no embedding object found in the KV store" << std::endl;
-               dbg_default_error("[{}]at {}, Failed to find object prefix {} in the KV store.", gettid(), __func__, embs_prefix);
-               return -1;
-          }
-          std::priority_queue<std::string, std::vector<std::string>, CompareObjKey> emb_obj_keys = filter_exact_matched_keys(listed_emb_obj_keys, embs_prefix);
+                                        DefaultCascadeContextType* typed_ctxt);
 
-          // 1. Get the cluster embeddings from KV store in Cascade
-          float* data;
-          int num_retrieved_embs = 0;
-          if (emb_obj_keys.size() == 1) {
-               std::string emb_obj_key = emb_obj_keys.top();
-               data = single_emb_object_retrieve(num_retrieved_embs, emb_obj_key, typed_ctxt, version, stable);
-          } else {
-               data = multi_emb_object_retrieve(num_retrieved_embs, emb_obj_keys, typed_ctxt, version ,stable);
-          }
-          if (num_retrieved_embs == 0) {
-               std::cerr << "Error: embs_prefix:" << embs_prefix <<" has no embeddings found in the KV store" << std::endl;
-               dbg_default_error("[{}]at {}, There is no embeddings for prefix{} in the KV store.", gettid(), __func__, embs_prefix);
-               return -1;
-          }
-          dbg_default_trace("[{}]: embs_prefix={}, num_emb_objects={} retrieved.", __func__, embs_prefix, num_retrieved_embs);
+     int get_num_embeddings(); 
 
-          // 2. assign the retrieved embeddings
-          this->num_embs = num_retrieved_embs;
-          this->embeddings = data;
-          // this->centroids_embs[cluster_id]= std::make_unique<GroupedEmbeddingsForSearch>(this->emb_dim, retrieved_num_embs, data);
-          // int init_search_res = this->initialize_groupped_embeddings_for_search();
-          return 0;
-     }
-
-     int get_num_embeddings(){
-          return this->num_embs;
-     }   
-
-     int initialize_groupped_embeddings_for_search(){
-          switch (this->search_type) {
-          case SearchType::FaissCpuFlatSearch:
-               initialize_cpu_flat_search();
-               break;
-          case SearchType::FaissGpuFlatSearch:
-               initialize_gpu_flat_search();
-               break;
-          case SearchType::FaissGpuIvfSearch:
-               initialize_gpu_ivf_flat_search();
-               break;
-          case SearchType::HnswlibCpuSearch:
-               initialize_cpu_hnsw_search();
-               break;
-          default:
-               std::cerr << "Error: faiss_search_type not supported" << std::endl;
-               dbg_default_error("Failed to initialize faiss search type, at clusters_search_udl.");
-               return -1;
-          }
-          initialized_index.store(true);
-          return 0;
-     }
+     int initialize_groupped_embeddings_for_search();
 
      /***
       * Search the top K embeddings that are close to one query
@@ -218,63 +149,17 @@ public:
       * @param D: distance array to store the distance of the top_k embeddings
       * @param I: index array to store the index of the top_k embeddings
       */
-     void search(int nq, float* xq, int top_k, float* D, long* I){
-          switch (this->search_type) {
-          case SearchType::FaissCpuFlatSearch:
-               faiss_cpu_flat_search(nq, xq, top_k, D, I);
-               break;
-          case SearchType::FaissGpuFlatSearch:
-               faiss_gpu_flat_search(nq, xq, top_k, D, I);
-               break;
-          case SearchType::FaissGpuIvfSearch:
-               faiss_gpu_ivf_flat_search(nq, xq, top_k, D, I);
-               break;
-          case SearchType::HnswlibCpuSearch:
-               hnsw_cpu_search(nq, xq, top_k, D, I);
-               break;
-          default:
-               std::cerr << "Error: faiss_search_type not supported" << std::endl;
-               dbg_default_error("Failed to search the top K embeddings, at clusters_search_udl.");
-               break;
-          }
-     }
+     void search(int nq, float* xq, int top_k, float* D, long* I);
 
-     void initialize_cpu_hnsw_search() {
-          this->l2_space = std::make_unique<hnswlib::L2Space>(this->emb_dim);
-          this->cpu_hnsw_index = std::make_unique<hnswlib::HierarchicalNSW<float>>(l2_space.get(), this->num_embs, M, EF_CONSTRUCTION);
+     void initialize_cpu_hnsw_search();
 
-          for(size_t i = 0; i < this->num_embs; i++) {
-               this->cpu_hnsw_index->addPoint(this->embeddings + (i * this->emb_dim), i);
-          }
-     }
-     int hnsw_cpu_search(int nq, float* xq, int top_k, float* D, long* I)  {
-          for(size_t i = 0; i < nq; i++) {
-               const float* query_vector = xq + (i * this->emb_dim);
+     int hnsw_cpu_search(int nq, float* xq, int top_k, float* D, long* I);
 
-               auto results = std::move(this->cpu_hnsw_index->searchKnn(query_vector, top_k));
-
-               for(size_t k = 0; k < top_k; k++) {
-                    auto [distance, idx] = results.top();
-                    results.pop();
-
-                    // populate distance vector which is (n, k)
-                    *(D + (i * top_k) + k) = distance;
-
-                    // populate index vector which is  also (n, k)
-                    *(I + (i * top_k) + k) = idx;
-               }
-          }
-
-          return 0;
-     }
      /*** 
       * Initialize the CPU flat search index based on the embeddings.
       * initalize it if use faiss_cpu_flat_search()
      ***/
-     void initialize_cpu_flat_search(){
-          this->cpu_flatl2_index = std::make_unique<faiss::IndexFlatL2>(this->emb_dim); 
-          this->cpu_flatl2_index->add(this->num_embs, this->embeddings); // add vectors to the index
-     }
+     void initialize_cpu_flat_search();
 
      /***
       * FAISS knn flat search on CPU
@@ -285,21 +170,13 @@ public:
       * @param D: distance array to store the distance of the top_k embeddings
       * @param I: index array to store the index of the top_k embeddings
      ***/
-     int faiss_cpu_flat_search(int nq, float* xq, int top_k, float* D, long* I){
-          dbg_default_trace("FAISS CPU flat Search in [GroupedEmbeddingsForSearch] class");
-          this->cpu_flatl2_index->search(nq, xq, top_k, D, I);
-          return 0;
-     }
+     int faiss_cpu_flat_search(int nq, float* xq, int top_k, float* D, long* I);
 
      /*** 
       * Initialize the GPU flat search index based on the embeddings.
       * initalize it if use faiss_gpu_flat_search()
      ***/
-     void initialize_gpu_flat_search(){
-          this->gpu_res = std::make_unique<faiss::gpu::StandardGpuResources>();
-          this->gpu_flatl2_index = std::make_unique<faiss::gpu::GpuIndexFlatL2>(this->gpu_res.get(), this->emb_dim);
-          this->gpu_flatl2_index->add(this->num_embs, this->embeddings); // add vectors to the index
-     }
+     void initialize_gpu_flat_search();
 
      /***
       * FAISS knn flat l2 search on GPU
@@ -310,23 +187,13 @@ public:
       * @param D: distance array to store the distance of the top_k embeddings
       * @param I: index array to store the index of the top_k embeddings
      ***/
-     int faiss_gpu_flat_search(int nq, float* xq, int top_k, float* D, long* I){
-          dbg_default_trace("FAISS GPU flatl2 Search in [GroupedEmbeddingsForSearch] class" );
-          this->gpu_flatl2_index->search(nq, xq, top_k, D, I);
-          return 0;
-     }
+     int faiss_gpu_flat_search(int nq, float* xq, int top_k, float* D, long* I);
 
      /*** 
       * Initialize the GPU ivf search index based on the embeddings.
       * initalize it if use faiss_gpu_ivf_flat_search()
      ***/
-     void initialize_gpu_ivf_flat_search(){
-          int nlist = 100;
-          this->gpu_res = std::make_unique<faiss::gpu::StandardGpuResources>();
-          this->gpu_ivf_flatl2_index = std::make_unique<faiss::gpu::GpuIndexIVFFlat>(this->gpu_res.get(), this->emb_dim, nlist, faiss::METRIC_L2);
-          this->gpu_ivf_flatl2_index->train(this->num_embs, this->embeddings); // train on the embeddings
-          this->gpu_ivf_flatl2_index->add(this->num_embs, this->embeddings); // add vectors to the index
-     }
+     void initialize_gpu_ivf_flat_search();
 
      /***
       * FAISS knn search based on ivf search on GPU
@@ -337,52 +204,13 @@ public:
       * @param D: distance array to store the distance of the top_k embeddings
       * @param I: index array to store the index of the top_k embeddings
      ***/
-     int faiss_gpu_ivf_flat_search(int nq, float* xq, int top_k, float* D, long* I){
-          dbg_default_trace("FAISS GPU ivf Search in [GroupedEmbeddingsForSearch] class" );
-          this->gpu_ivf_flatl2_index->search(nq, xq, top_k, D, I);
-          return 0;
-     }
+     int faiss_gpu_ivf_flat_search(int nq, float* xq, int top_k, float* D, long* I);
 
      /***
       * Reset the GroupedEmbeddingsForSearch object
       * This function is called when the UDL is released
       */
-     void reset(){
-          if (this->embeddings != nullptr) {
-               free(this->embeddings);
-               this->embeddings = nullptr; 
-          }
-          // index cleanup 
-          if (this->search_type == SearchType::FaissCpuFlatSearch && this->cpu_flatl2_index != nullptr) {
-               this->cpu_flatl2_index->reset();
-          } 
-          else if (this->search_type == SearchType::FaissGpuFlatSearch && this->gpu_flatl2_index != nullptr) {
-               cudaError_t sync_err = cudaDeviceSynchronize();
-               if (sync_err == cudaSuccess) {
-                    this->gpu_flatl2_index->reset();  
-                    this->gpu_res.reset();
-                    this->gpu_flatl2_index=nullptr;
-                    this->gpu_res=nullptr;
-                    cudaDeviceReset();  
-               } else {
-                    std::cerr << "Error during cudaDeviceSynchronize: " << cudaGetErrorString(sync_err) << std::endl;
-               }
-          } 
-          else if (this->search_type == SearchType::FaissGpuIvfSearch && this->gpu_ivf_flatl2_index != nullptr) {
-               cudaError_t sync_err = cudaDeviceSynchronize();
-               if (sync_err == cudaSuccess) {
-                    this->gpu_ivf_flatl2_index->reset();  
-                    this->gpu_res.reset();
-                    this->gpu_ivf_flatl2_index=nullptr;
-                    this->gpu_res=nullptr;
-                    cudaDeviceReset();  
-               } else {
-                    std::cerr << "Error during cudaDeviceSynchronize: " << cudaGetErrorString(sync_err) << std::endl;
-               }
-          } else if (this->search_type == SearchType::HnswlibCpuSearch && this -> cpu_flatl2_index != nullptr) {
-               this->cpu_hnsw_index.reset();
-          }
-     }
+     void reset();
 
      ~GroupedEmbeddingsForSearch() {
           // free(embeddings);

--- a/vortex_udls/serialize_utils.cpp
+++ b/vortex_udls/serialize_utils.cpp
@@ -177,7 +177,7 @@ void deserialize_embeddings_and_quries_from_bytes(const uint8_t* bytes,
 * Format the search results for each query to send to the next UDL.
 * The format is | top_k | embeding_id_vector | distance_vector | query_text |
 ***/
-std::string serialize_cluster_search_result(uint32_t top_k, long* I, float* D, int idx, std::string& query_text){
+std::string serialize_cluster_search_result(uint32_t top_k, long* I, float* D, int idx, const std::string& query_text){
      std::string query_search_result;
      std::string num_embs(4, '\0');  // denotes the number of embedding_ids and distances 
      num_embs[0] = (top_k >> 24) & 0xFF;

--- a/vortex_udls/serialize_utils.hpp
+++ b/vortex_udls/serialize_utils.hpp
@@ -60,7 +60,7 @@ void deserialize_embeddings_and_quries_from_bytes(const uint8_t* bytes,
 * Format the search results for each query to send to the next UDL.
 * The format is | top_k | embeding_id_vector | distance_vector | query_text |
 ***/
-std::string serialize_cluster_search_result(uint32_t top_k, long* I, float* D, int idx, std::string& query_text);
+std::string serialize_cluster_search_result(uint32_t top_k, long* I, float* D, int idx, const std::string& query_text);
 
 
 struct DocIndex{


### PR DESCRIPTION
- refactored code at Aggregate UDL, aggregate now by client_id+query_batch_id instead of std::string
- fixed local queue at cluster Search too use dynamically expandable queue for processing cluster_search, to avoid blocking the main cascade thread